### PR TITLE
Fixes for issues #73, #77.

### DIFF
--- a/script/hatchet.ini
+++ b/script/hatchet.ini
@@ -1,12 +1,12 @@
 [run]
 # What individual steps of HATCHet should we run in the pipeline?
 # Valid values are True or False
-count_reads = False 
-genotype_snps = False 
-count_alleles = False 
-combine_counts = False 
-cluster_bins = False 
-plot_bins = False 
+count_reads = True
+genotype_snps = True
+count_alleles = True
+combine_counts = True
+cluster_bins = True
+plot_bins = True
 compute_cn = True 
 plot_cn = True 
 

--- a/setup.py
+++ b/setup.py
@@ -76,7 +76,7 @@ class CMakeBuild(build_ext):
 
 setup(
     name='hatchet',
-    version='0.3.2',
+    version='0.3.3',
     packages=['hatchet', 'hatchet.utils', 'hatchet.bin'],
     package_dir={'': 'src'},
     package_data={'hatchet': ['hatchet.ini']},

--- a/src/hatchet/__init__.py
+++ b/src/hatchet/__init__.py
@@ -1,4 +1,4 @@
-__version__ = '0.3.2'
+__version__ = '0.3.3'
 
 import os.path
 from importlib.resources import path

--- a/src/hatchet/utils/cluster_bins.py
+++ b/src/hatchet/utils/cluster_bins.py
@@ -43,6 +43,8 @@ def main(args=None):
     for key in sorted(combo, key=(lambda x : (sp.numericOrder(x[0]), int(x[1]), int(x[2])))):
         for sample in sorted(combo[key]):
             outbins.write("{}\t{}\t{}\t{}\t{}\t{}\t{}\t{}\t{}\t{}\t{}\n".format(key[0], key[1], key[2], sample[0], sample[1], sample[2], sample[3], sample[4], sample[5], sample[6], clusterAssignments[bintoidx[key]]))
+    if outbins is not sys.stdout:
+        outbins.close()
 
     sp.log(msg="# Segmenting bins\n", level="STEP")
     clusters = {cluster : set(key for key in combo if clusterAssignments[bintoidx[key]] == cluster) for cluster in set(clusterAssignments)}
@@ -60,6 +62,8 @@ def main(args=None):
         for sample in sorted(segments[key]):
             record = segments[key][sample]
             outsegments.write("{}\t{}\t{}\t{}\t{}\t{}\t{}\t{}\t{}\n".format(key, sample, record[0], record[1], record[2], record[3], record[4], record[5], record[6]))
+    if outsegments is not sys.stdout:
+        outsegments.close()
 
 
 def readBB(bbfile):

--- a/src/hatchet/utils/plot_cn.py
+++ b/src/hatchet/utils/plot_cn.py
@@ -42,7 +42,7 @@ def parsing_arguments(args=None):
     parser.add_argument("-n","--patientnames", required=False, default=config.plot_cn.patientnames, type=str, help='Names of patients between apices (default: inferred from filenames)')
     parser.add_argument("-u","--minu", required=False, default=config.plot_cn.minu, type=float, help='Minimum proportion of a CNA to be considered subclonal (default: 0.2)"')
     parser.add_argument("-x","--rundir", required=False, default=config.plot_cn.rundir, type=str, help='Running directory (default: current directory)')
-    parser.add_argument("-b","--baseCN", required=False, default=config.plot_cn.basecn, type=str, help='Base copy number (default: inferred from tumor ploidy)')
+    parser.add_argument("-b","--baseCN", required=False, default=config.plot_cn.basecn, type=int, help='Base copy number (default: inferred from tumor ploidy)')
     parser.add_argument("-sC","--figsizeclones", required=False, default=config.plot_cn.figsizeclones, type=str, help='Size of clone plots in the form "(X-SIZE, Y-SIZE)"')
     parser.add_argument("-sP","--figsizecn", required=False, default=config.plot_cn.figsizecn, type=str, help='Size of CN plots in the form "(X-SIZE, Y-SIZE)"')
     parser.add_argument("-sG","--figsizegrid", required=False, default=config.plot_cn.figsizegrid, type=str, help='Size of grid plots in the form "(X-SIZE, Y-SIZE)"')

--- a/src/hatchet/utils/run.py
+++ b/src/hatchet/utils/run.py
@@ -60,7 +60,9 @@ def main(args=None):
 
     if config.run.genotype_snps:
         snps = ''
-        if config.genotype_snps.reference_version and not config.genotype_snps.snps:
+        if config.genotype_snps.snps:
+           snps = config.genotype_snps.snps
+        elif config.genotype_snps.reference_version:
             snps_mapping = {
                 ('hg19', True): 'https://ftp.ncbi.nih.gov/snp/organisms/human_9606_b151_GRCh37p13/VCF/GATK/00-All.vcf.gz',
                 ('hg19', False): 'https://ftp.ncbi.nih.gov/snp/organisms/human_9606_b151_GRCh37p13/VCF/00-All.vcf.gz',


### PR DESCRIPTION
Another bug fix wherein specification of `genotype_snps.snps` in the .ini would have had no effect, had `genotype_snps.reference_version` also been specified.