### PR TITLE
Support to set compute_cn.timelimit for pyomo solvers

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -76,7 +76,7 @@ class CMakeBuild(build_ext):
 
 setup(
     name='hatchet',
-    version='0.4.4',
+    version='0.4.5',
     packages=['hatchet', 'hatchet.utils', 'hatchet.utils.solve', 'hatchet.bin', 'hatchet.data'],
     package_dir={'': 'src'},
     package_data={'hatchet': ['hatchet.ini'], 'hatchet.data': ['*']},

--- a/src/hatchet/__init__.py
+++ b/src/hatchet/__init__.py
@@ -1,4 +1,4 @@
-__version__ = '0.4.4'
+__version__ = '0.4.5'
 
 import os.path
 from importlib.resources import path

--- a/src/hatchet/utils/solve/ilp_subset.py
+++ b/src/hatchet/utils/solve/ilp_subset.py
@@ -4,6 +4,7 @@ import pandas as pd
 from pyomo import environ as pe
 from pyomo.opt import SolverStatus, TerminationCondition
 
+from hatchet import config
 from hatchet.utils.solve.utils import Random
 
 
@@ -531,12 +532,13 @@ class ILPSubset:
                 U[:, _k] = v
         return U
 
-    def run(self, solver_type='gurobi', timelimit=100, write_path=None):
+    def run(self, solver_type='gurobi', timelimit=None, write_path=None):
         if solver_type == 'gurobipy':
             solver = pe.SolverFactory('gurobi', solver_io='python')
         else:
             solver = pe.SolverFactory(solver_type)
 
+        timelimit = int(timelimit or config.compute_cn.timelimit or 100)
         kwargs = {'timelimit': timelimit, 'report_timing': False}
         if solver.warm_start_capable():
             kwargs['warmstart'] = self.warmstart


### PR DESCRIPTION
The CPP solver always had a `timelimit` parameter for each ILP iteration specifiable on the command line, or through the `compute_cn.timelimit` ini variable (or the `HATCHET_COMPUTE_CN_TIMELIMIT` envvar). This tweak passes the same flag to pyomo supported solvers too. In case the timelimit is not specified (the default as before), we're using the (reasonable) time limit of 100 seconds (the default pyomo timelimit up until this tweak).