### PR TITLE
Cn bugfix

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -76,7 +76,7 @@ class CMakeBuild(build_ext):
 
 setup(
     name='hatchet',
-    version='0.4.5',
+    version='0.4.6',
     packages=['hatchet', 'hatchet.utils', 'hatchet.utils.solve', 'hatchet.bin', 'hatchet.data'],
     package_dir={'': 'src'},
     package_data={'hatchet': ['hatchet.ini'], 'hatchet.data': ['*']},

--- a/src/hatchet/__init__.py
+++ b/src/hatchet/__init__.py
@@ -1,4 +1,4 @@
-__version__ = '0.4.5'
+__version__ = '0.4.6'
 
 import os.path
 from importlib.resources import path

--- a/src/hatchet/utils/ArgParsing.py
+++ b/src/hatchet/utils/ArgParsing.py
@@ -228,7 +228,7 @@ def parse_count_reads_arguments(args=None):
     if not os.path.isfile(normalbaf): raise ValueError(sp.error("The specified normal BAM file does not exist"))
     tumors = args.tumors
     for tumor in tumors:
-        if(not os.path.isfile(tumor)): raise ValueError(sp.error("The specified normal BAM file does not exist"))
+        if(not os.path.isfile(tumor)): raise ValueError(sp.error(f"The specified tumor BAM file {tumor} does not exist"))
     names = args.samples
     if names != None and (len(tumors)+1) != len(names):
         raise ValueError(sp.error("A sample name must be provided for each corresponding BAM: both for each normal sample and each tumor sample"))

--- a/src/hatchet/utils/solve/utils.py
+++ b/src/hatchet/utils/solve/utils.py
@@ -33,16 +33,19 @@ def parse_clonal(clonal):
     copy_numbers = OrderedDict()  # dict from cluster_id => (cn_a, cn_b) 2-tuple
     clonal_parts = clonal.split(',')
     n_clonal_parts = len(clonal_parts)
-    cn_totals = set()
 
-    for c in clonal_parts:
+    for i, c in enumerate(clonal_parts):
         cluster_id, cn_a, cn_b = [int(_c) for _c in c.split(':')]
+
+        # The first two clonal clusters (used for scaling) MUST have different total copy numbers
+        if i==1:
+            _first_cn_a, _first_cn_b = list(copy_numbers.values())[0]
+            if _first_cn_a + _first_cn_b == cn_a + cn_b:
+                raise ValueError('When >= 2 clonal copy numbers are given, the first two must be different in the two segmental clusters')
+
         cn_total = cn_a + cn_b
         if (cn_total == 2) and (n_clonal_parts > 1):
             warnings.warn('Please specify a single cluster when CN_A+CN_B=2')
-        if cn_total in cn_totals:
-            raise ValueError('Cannot specify two clusters with same CN_A+CN_B')
-        cn_totals.add(cn_total)
         if cluster_id in copy_numbers:
             raise ValueError('Already encountered cluster_id =', str(cluster_id))
         copy_numbers[cluster_id] = cn_a, cn_b


### PR DESCRIPTION
Bug fix when parsing clonal cn strings - only the first two (used for scaling) need to have their total copy numbers different. The existing code insists that ALL clonal segments have their total copy numbers different, which is a bug.