### PR TITLE
Locale errors fix

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -76,7 +76,7 @@ class CMakeBuild(build_ext):
 
 setup(
     name='hatchet',
-    version='0.4.6',
+    version='0.4.7',
     packages=['hatchet', 'hatchet.utils', 'hatchet.utils.solve', 'hatchet.bin', 'hatchet.data'],
     package_dir={'': 'src'},
     package_data={'hatchet': ['hatchet.ini'], 'hatchet.data': ['*']},

--- a/src/coordinate_descent.cpp
+++ b/src/coordinate_descent.cpp
@@ -185,6 +185,7 @@ void CoordinateDescent::runWorker()
             
             {
                 std::lock_guard<std::mutex> lock(g_output_mutex);
+                std::locale::global(std::locale("C"));
                 log(std::to_string(obj) + "; ", VERBOSITY_t::VERBOSE, _v);
             }
         } else {

--- a/src/hatchet/__init__.py
+++ b/src/hatchet/__init__.py
@@ -1,4 +1,4 @@
-__version__ = '0.4.6'
+__version__ = '0.4.7'
 
 import os.path
 from importlib.resources import path

--- a/src/worker.cpp
+++ b/src/worker.cpp
@@ -47,6 +47,7 @@ Worker::Worker(const DoubleMatrix& FA,
     , _seedIndex(seedIndex)
     , _v(v)
 {
+    std::locale::global(std::locale("C"));
 }
 
 


### PR DESCRIPTION
In addition to the locale fix in the Worker object (as was tried earlier), there's an additional place in `coordinate_descent.cpp` where the fix needs to be put. Non-scientific experimentation shows that putting the fix:

```
std::locale::global(std::locale("C"));
```

anywhere except in the block where `std::to_string(<float>)` is called causes a comma-separated string to be generated in some cases.