### PR TITLE
Ability to run compute-cn when building with HATCHET_BUILD_NOEXT=1

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -76,7 +76,7 @@ class CMakeBuild(build_ext):
 
 setup(
     name='hatchet',
-    version='0.4.7',
+    version='0.4.8',
     packages=['hatchet', 'hatchet.utils', 'hatchet.utils.solve', 'hatchet.bin', 'hatchet.data'],
     package_dir={'': 'src'},
     package_data={'hatchet': ['hatchet.ini'], 'hatchet.data': ['*']},

--- a/src/hatchet/__init__.py
+++ b/src/hatchet/__init__.py
@@ -1,4 +1,4 @@
-__version__ = '0.4.7'
+__version__ = '0.4.8'
 
 import os.path
 from importlib.resources import path

--- a/src/hatchet/__main__.py
+++ b/src/hatchet/__main__.py
@@ -4,7 +4,6 @@ python -m hatchet <command> <arguments> ..
 """
 
 import sys
-import os.path
 import warnings
 import hatchet
 from hatchet.utils.count_reads import main as count_reads
@@ -18,8 +17,6 @@ from hatchet.utils.plot_cn import main as plot_cn
 
 from hatchet.utils.check_solver import main as check_solver
 from hatchet.utils.run import main as run
-
-solve_bin = os.path.join(os.path.dirname(hatchet.__file__), 'solve')
 
 commands = ('count-reads', 'genotype-snps', 'count-alleles', 'combine-counts', 'cluster-bins', 'plot-bins',
             'compute-cn', 'plot-cn', 'check-solver', 'run')
@@ -60,11 +57,8 @@ def main():
         sys.exit(1)
 
     command = aliases.get(command, command)
-    if command != 'compute-cn':
-        command = command.replace('-', '_')
-        globals()[command](args)
-    else:
-        compute_cn([solve_bin] + args)
+    command = command.replace('-', '_')
+    globals()[command](args)
 
 
 if __name__ == '__main__':

--- a/src/hatchet/bin/HATCHet.py
+++ b/src/hatchet/bin/HATCHet.py
@@ -9,6 +9,7 @@ import multiprocessing as mp
 import shlex
 from collections import Counter
 
+import hatchet
 from hatchet import config, __version__
 from hatchet.utils.solve import solve
 from hatchet.utils.solve.utils import segmentation
@@ -21,7 +22,7 @@ def parsing_arguments(args=None):
     """
     description = ""
     parser = argparse.ArgumentParser(prog='hatchet compute-cn', description=description, formatter_class=argparse.RawTextHelpFormatter)
-    parser.add_argument("SOLVER", help="Path to the executable solver")
+    parser.add_argument("SOLVER", type=str, nargs='?', help="Path to the executable solver")
     parser.add_argument("-i","--input", type=str, required=True, help="Prefix path to seg and bbc input files (required)")
     parser.add_argument("-x","--runningdir", type=str, required=False, default=config.compute_cn.runningdir, help="Running directory (default: ./)")
     parser.add_argument("-n","--clones", type=str, required=False, default=config.compute_cn.clones, help="Either an estimated number of clones or an interval where the\nnumber of clones should be looked for given in the form LOWER,UPPER where LOWER and UPPER are two integer defining the interval (default: 2,8)")
@@ -54,8 +55,12 @@ def parsing_arguments(args=None):
     parser.add_argument("-V", "--version", action='version', version=f'%(prog)s {__version__}')
     args = parser.parse_args(args)
 
-    if not os.path.isfile(args.SOLVER):
-        raise ValueError(error("Solver not found in {}!".format(args.SOLVER)))
+    if config.compute_cn.solver == 'cpp':
+        if args.SOLVER is None:
+            args.SOLVER = os.path.join(os.path.dirname(hatchet.__file__), 'solve')
+        if not os.path.isfile(args.SOLVER):
+            raise ValueError(error("Solver not found in {}!".format(args.SOLVER)))
+
     clusters = args.input + '.seg'
     if not os.path.isfile(clusters):
         raise ValueError(error("SEG file {} not found!".format(clusters)))

--- a/src/hatchet/utils/check_solver.py
+++ b/src/hatchet/utils/check_solver.py
@@ -10,7 +10,6 @@ from hatchet.utils.Supporting import log
 
 this_dir = os.path.dirname(__file__)
 DATA_FOLDER = os.path.join(this_dir, 'data')
-solve_binary = os.path.join(os.path.dirname(hatchet.__file__), 'solve')
 
 
 def main(args=None):
@@ -20,7 +19,6 @@ def main(args=None):
         with path(hatchet.data, 'sample.bbc') as bbc_path:
             input_files_prefix = os.path.splitext(bbc_path)[0]
             hatchet_main(args=[
-                solve_binary,
                 '-x', os.path.join(tempdirname),
                 '-i', input_files_prefix,
                 '-n2',

--- a/src/hatchet/utils/run.py
+++ b/src/hatchet/utils/run.py
@@ -4,7 +4,6 @@ import os.path
 import glob
 import argparse
 
-import hatchet
 from hatchet import config
 from hatchet.utils.count_reads import main as count_reads
 from hatchet.utils.genotype_snps import main as genotype_snps
@@ -14,8 +13,6 @@ from hatchet.utils.cluster_bins import main as cluster_bins
 from hatchet.utils.plot_bins import main as plot_bins
 from hatchet.bin.HATCHet import main as hatchet_main
 from hatchet.utils.plot_cn import main as plot_cn
-
-solve_binary = os.path.join(os.path.dirname(hatchet.__file__), 'solve')
 
 
 def main(args=None):
@@ -150,7 +147,6 @@ def main(args=None):
         os.makedirs(f'{output}/results', exist_ok=True)
         hatchet_main(
             args=[
-                solve_binary,
                 '-x', f'{output}/results',
                 '-i', f'{output}/bbc/bulk'
             ] + extra_args

--- a/tests/test_script.py
+++ b/tests/test_script.py
@@ -21,7 +21,6 @@ from hatchet.utils.plot_cn import main as plot_cn
 from hatchet.utils.solve import solver_available
 
 this_dir = os.path.dirname(__file__)
-SOLVE = os.path.join(os.path.dirname(hatchet.__file__), 'solve')
 
 
 @pytest.fixture(scope='module')
@@ -142,7 +141,6 @@ def test_script(_, bams, output_folder):
 
     if solver_available():
         main(args=[
-            SOLVE,
             '-x', os.path.join(output_folder, 'results'),
             '-i', os.path.join(output_folder, 'bbc/bulk'),
             '-n2',

--- a/tests/test_solver.py
+++ b/tests/test_solver.py
@@ -43,7 +43,6 @@ def test_solve_command_cpp(output_folder):
     config.compute_cn.solver = 'cpp'
 
     main(args=[
-        SOLVE,
         '-x', os.path.join(output_folder),
         '-i', os.path.join(this_dir, 'data/bulk'),
         '-n2',
@@ -72,7 +71,6 @@ def test_solve_command_gurobipy(output_folder):
     config.compute_cn.solver = 'gurobipy'
 
     main(args=[
-        SOLVE,
         '-x', os.path.join(output_folder),
         '-i', os.path.join(this_dir, 'data/bulk'),
         '-n2',
@@ -101,7 +99,6 @@ def test_solve_command_gurobi(output_folder):
     config.compute_cn.solver = 'gurobi'
 
     main(args=[
-        SOLVE,
         '-x', os.path.join(output_folder),
         '-i', os.path.join(this_dir, 'data/bulk'),
         '-n2',
@@ -130,7 +127,6 @@ def test_solve_command_cbc(output_folder):
     config.compute_cn.solver = 'cbc'
 
     main(args=[
-        SOLVE,
         '-x', os.path.join(output_folder),
         '-i', os.path.join(this_dir, 'data/bulk'),
         '-n2',


### PR DESCRIPTION
Bug fix (using HATCHet without first compiling the C++ components would have prevented use of `compute-cn`, even if using a pyomo-supported solver).