### PR TITLE
bug fix with tempfile path join

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -76,7 +76,7 @@ class CMakeBuild(build_ext):
 
 setup(
     name='hatchet',
-    version='0.4.9',
+    version='0.4.11',
     packages=['hatchet', 'hatchet.utils', 'hatchet.utils.solve', 'hatchet.bin', 'hatchet.data'],
     package_dir={'': 'src'},
     package_data={'hatchet': ['hatchet.ini'], 'hatchet.data': ['*']},

--- a/src/hatchet/__init__.py
+++ b/src/hatchet/__init__.py
@@ -1,4 +1,4 @@
-__version__ = '0.4.9'
+__version__ = '0.4.11'
 
 import os.path
 from importlib.resources import path

--- a/src/hatchet/utils/count_alleles.py
+++ b/src/hatchet/utils/count_alleles.py
@@ -36,7 +36,7 @@ def main(args=None):
     with tempfile.TemporaryDirectory(dir=args["outputSnps"]) as tmpdirname:
         hetsnpsfiles = {}
         for chro in args["chromosomes"]:
-            hetsnpsfiles[chro] = os.path.join(args["outputSnps"], tmpdirname, 'TMP_{}.tsv'.format(chro))
+            hetsnpsfiles[chro] = os.path.join(tmpdirname, 'TMP_{}.tsv'.format(chro))
             with open(hetsnpsfiles[chro], 'w') as f:
                 if (args["normal"][1], chro) in hetSNPs:
                     for snp in sorted(hetSNPs[args["normal"][1], chro]):


### PR DESCRIPTION
Bug fix (`tmpdirname` already has the directory prefix inside it, so it doesn't need to be joined again).
Need to investigate how this was working in the CI in the first place!

This is for issue #117 