### PR TITLE
Indexing using tabix before calling it for a chromosome

### DIFF
--- a/src/hatchet/utils/count_reads.py
+++ b/src/hatchet/utils/count_reads.py
@@ -114,6 +114,11 @@ def main(args=None):
             if ch not in chr2centro:
                 raise ValueError(error(f"Chromosome {ch} not found in centromeres file. Inspect file provided as -C argument."))
 
+        # Use Tabix to index per-position coverage bed files for each sample
+        for name in names:
+            perpos_file = os.path.join(outdir, name + '.per-base.bed.gz')
+            subprocess.run([tabix, '-f', perpos_file])
+
         # form parameters for each worker
         params = [(outdir, names, ch,
                 chr2centro[ch][0], chr2centro[ch][1], args['baf_file'], tabix)


### PR DESCRIPTION
I found that on my installation of `tabix` and `mosdepth`, the step at
https://github.com/raphael-group/hatchet/blob/eb696ce9ff40655a0119cabae7fdcdb4e61a22e1/src/hatchet/utils/count_reads.py#L169

produces (among other files), an index file with the `.csi` extension. A later step at
https://github.com/raphael-group/hatchet/blob/eb696ce9ff40655a0119cabae7fdcdb4e61a22e1/src/hatchet/utils/count_reads.py#L309

fails to run because `tabix` complains of a missing index file.

In my case, I found that explicitly force-creating the tabix index for every gz file before trying to call tabix for every chromosome solves the issue. This seems a reasonable step to me to perform in any case, though you may have a better fix for this.
