### PR TITLE
more checks; cached checks; iterating through all supported commands

### DIFF
--- a/src/hatchet/__main__.py
+++ b/src/hatchet/__main__.py
@@ -7,6 +7,8 @@ import sys
 import warnings
 import hatchet
 
+from hatchet.utils.commands import commands, command_aliases
+
 from hatchet.utils.count_reads import main as count_reads  # noqa: F401
 from hatchet.utils.count_reads_fw import main as count_reads_fw  # noqa: F401
 from hatchet.utils.genotype_snps import main as genotype_snps  # noqa: F401
@@ -28,26 +30,6 @@ from hatchet.utils.phase_snps import main as phase_snps  # noqa: F401
 
 from hatchet.utils.check import main as check  # noqa: F401
 
-commands = (
-    'count-reads',
-    'count-reads-fw',
-    'genotype-snps',
-    'count-alleles',
-    'combine-counts',
-    'combine-counts-fw',
-    'cluster-bins',
-    'plot-bins',
-    'compute-cn',
-    'plot-cn',
-    'run',
-    'check',
-    'download-panel',
-    'phase-snps',
-    'cluster-bins-loc',
-    'plot-cn-1d2d',
-    'plot-bins-1d2d',
-)
-
 
 def print_usage():
     print('HATCHet v' + hatchet.__version__)
@@ -56,20 +38,6 @@ def print_usage():
 
 
 def main():
-    # support for old command names as they've been used in earlier versions of HATCHet
-    aliases = {
-        'binBAM': 'count-reads-fw',
-        'SNPCaller': 'genotype-snps',
-        'deBAF': 'count-alleles',
-        'comBBo': 'combine-counts-fw',
-        'cluBB': 'cluster-bins',
-        'BBot': 'plot-bins',
-        'solve': 'compute-cn',
-        'BBeval': 'plot-cn',
-        'PhasePrep': 'download-panel',
-        'Phase': 'phase-snps',
-        'check-solver': 'check',
-    }
 
     if len(sys.argv) < 2:
         print_usage()
@@ -78,9 +46,9 @@ def main():
     command = sys.argv[1]
     args = sys.argv[2:]
 
-    if command in aliases:
+    if command in command_aliases:
         msg = (
-            f'The HATCHet command "{command}" has been replaced by "{aliases[command]}" and will be absent in '
+            f'The HATCHet command "{command}" has been replaced by "{command_aliases[command]}" and will be absent in '
             f'future releases. Please update your scripts accordingly.'
         )
         warnings.warn(msg, FutureWarning)
@@ -88,7 +56,7 @@ def main():
         print_usage()
         sys.exit(1)
 
-    command = aliases.get(command, command)
+    command = command_aliases.get(command, command)
     command = command.replace('-', '_')
     globals()[command](args)
 

--- a/src/hatchet/utils/commands.py
+++ b/src/hatchet/utils/commands.py
@@ -1,0 +1,36 @@
+# All supported HATCHet commands
+commands = (
+    'count-reads',
+    'count-reads-fw',
+    'genotype-snps',
+    'count-alleles',
+    'combine-counts',
+    'combine-counts-fw',
+    'cluster-bins',
+    'plot-bins',
+    'compute-cn',
+    'plot-cn',
+    'run',
+    'check',
+    'download-panel',
+    'phase-snps',
+    'cluster-bins-loc',
+    'plot-cn-1d2d',
+    'plot-bins-1d2d',
+)
+
+
+# Support for old command names as they've been used in earlier versions of HATCHet
+command_aliases = {
+    'binBAM': 'count-reads-fw',
+    'SNPCaller': 'genotype-snps',
+    'deBAF': 'count-alleles',
+    'comBBo': 'combine-counts-fw',
+    'cluBB': 'cluster-bins',
+    'BBot': 'plot-bins',
+    'solve': 'compute-cn',
+    'BBeval': 'plot-cn',
+    'PhasePrep': 'download-panel',
+    'Phase': 'phase-snps',
+    'check-solver': 'check',
+}


### PR DESCRIPTION
- Going through all available `HATCHet` commands to see if any checks are supported.
- Added checks for samtools/bcftools at the appropriate places.
- Check results cached across steps since a lot of steps use the same external binaries (samtools etc.)