### PR TITLE
Vb/checkbetter

### DIFF
--- a/src/hatchet/__main__.py
+++ b/src/hatchet/__main__.py
@@ -7,6 +7,8 @@ import sys
 import warnings
 import hatchet
 
+from hatchet.utils.commands import commands, command_aliases
+
 from hatchet.utils.count_reads import main as count_reads  # noqa: F401
 from hatchet.utils.count_reads_fw import main as count_reads_fw  # noqa: F401
 from hatchet.utils.genotype_snps import main as genotype_snps  # noqa: F401
@@ -28,26 +30,6 @@ from hatchet.utils.phase_snps import main as phase_snps  # noqa: F401
 
 from hatchet.utils.check import main as check  # noqa: F401
 
-commands = (
-    'count-reads',
-    'count-reads-fw',
-    'genotype-snps',
-    'count-alleles',
-    'combine-counts',
-    'combine-counts-fw',
-    'cluster-bins',
-    'plot-bins',
-    'compute-cn',
-    'plot-cn',
-    'run',
-    'check',
-    'download-panel',
-    'phase-snps',
-    'cluster-bins-loc',
-    'plot-cn-1d2d',
-    'plot-bins-1d2d',
-)
-
 
 def print_usage():
     print('HATCHet v' + hatchet.__version__)
@@ -56,20 +38,6 @@ def print_usage():
 
 
 def main():
-    # support for old command names as they've been used in earlier versions of HATCHet
-    aliases = {
-        'binBAM': 'count-reads-fw',
-        'SNPCaller': 'genotype-snps',
-        'deBAF': 'count-alleles',
-        'comBBo': 'combine-counts-fw',
-        'cluBB': 'cluster-bins',
-        'BBot': 'plot-bins',
-        'solve': 'compute-cn',
-        'BBeval': 'plot-cn',
-        'PhasePrep': 'download-panel',
-        'Phase': 'phase-snps',
-        'check-solver': 'check',
-    }
 
     if len(sys.argv) < 2:
         print_usage()
@@ -78,9 +46,9 @@ def main():
     command = sys.argv[1]
     args = sys.argv[2:]
 
-    if command in aliases:
+    if command in command_aliases:
         msg = (
-            f'The HATCHet command "{command}" has been replaced by "{aliases[command]}" and will be absent in '
+            f'The HATCHet command "{command}" has been replaced by "{command_aliases[command]}" and will be absent in '
             f'future releases. Please update your scripts accordingly.'
         )
         warnings.warn(msg, FutureWarning)
@@ -88,7 +56,7 @@ def main():
         print_usage()
         sys.exit(1)
 
-    command = aliases.get(command, command)
+    command = command_aliases.get(command, command)
     command = command.replace('-', '_')
     globals()[command](args)
 

--- a/src/hatchet/utils/check.py
+++ b/src/hatchet/utils/check.py
@@ -59,6 +59,14 @@ def _check_tabix():
             return _check_cmd(config.paths.tabix, 'tabix', '-p', 'gff', _temp_gz_path, '-f')
 
 
+def _check_bgzip():
+    with tempfile.TemporaryDirectory() as tempdirname:
+        with importlib.resources.path(hatchet.data, 'sample.bbc') as file_path:
+            _temp_file_path = os.path.join(tempdirname, 'sample.bbc')
+            shutil.copy(file_path, _temp_file_path)
+            return _check_cmd(config.paths.bgzip, 'bgzip', _temp_file_path, '-f')
+
+
 def _check_picard():
     picard_dir = config.paths.picard
     picard_java_flags = config.phase_snps.picard_java_flags
@@ -216,6 +224,14 @@ CHECKS = {
             config.paths.shapeit,
             'shapeit',
             '--version',
+        ),
+        (
+            'bgzip',
+            '',
+            'Please install the bgzip executable and either ensure its on your PATH, or its location specified in '
+            'hatchet.ini as config.paths.bgzip, or its location specified using the environment variable '
+            'HATCHET_PATHS_BGZIP. Note that bgzip can often be found at the same location as the tabix executable.',
+            _check_bgzip,
         ),
     ],
     'compute-cn': [

--- a/src/hatchet/utils/commands.py
+++ b/src/hatchet/utils/commands.py
@@ -1,0 +1,36 @@
+# All supported HATCHet commands
+commands = (
+    'count-reads',
+    'count-reads-fw',
+    'genotype-snps',
+    'count-alleles',
+    'combine-counts',
+    'combine-counts-fw',
+    'cluster-bins',
+    'plot-bins',
+    'compute-cn',
+    'plot-cn',
+    'run',
+    'check',
+    'download-panel',
+    'phase-snps',
+    'cluster-bins-loc',
+    'plot-cn-1d2d',
+    'plot-bins-1d2d',
+)
+
+
+# Support for old command names as they've been used in earlier versions of HATCHet
+command_aliases = {
+    'binBAM': 'count-reads-fw',
+    'SNPCaller': 'genotype-snps',
+    'deBAF': 'count-alleles',
+    'comBBo': 'combine-counts-fw',
+    'cluBB': 'cluster-bins',
+    'BBot': 'plot-bins',
+    'solve': 'compute-cn',
+    'BBeval': 'plot-cn',
+    'PhasePrep': 'download-panel',
+    'Phase': 'phase-snps',
+    'check-solver': 'check',
+}


### PR DESCRIPTION
Iterating through all available HATCHet commands in `hatchet check` to see if any checks are specified for a command. A single check is now added for all commands where it is relevant, though the check results are cached internally if a check has already been run.

Added checks for samtools/bcftools/bgzip. Closes issue #130