### PR TITLE
Fixing phasing snps arguments and LiftOver

### DIFF
--- a/src/hatchet/utils/phase_snps.py
+++ b/src/hatchet/utils/phase_snps.py
@@ -247,8 +247,8 @@ class Phaser(Worker):
         # e.g. small contigs variably present among the assemblies
 
         cmd1 = (
-            f'{self.picard} LiftoverVcf -I={infile} -O={tmpfile} -CHAIN={chain} -R={refgen} -REJECT={rejfile} '
-            '--WARN_ON_MISSING_CONTIG=true'
+            f'{self.picard} LiftoverVcf I={infile} O={tmpfile} CHAIN={chain} R={refgen} REJECT={rejfile} '
+            'WARN_ON_MISSING_CONTIG=true'
         )
         # need to change 'chr' notation depending on liftover direction
         c = chromosome if not ch else f'chr{chromosome}'

--- a/src/hatchet/utils/phase_snps.py
+++ b/src/hatchet/utils/phase_snps.py
@@ -247,8 +247,8 @@ class Phaser(Worker):
         # e.g. small contigs variably present among the assemblies
 
         cmd1 = (
-            f'{self.picard} LiftoverVcf -I {infile} -O {tmpfile} -CHAIN {chain} -R {refgen} -REJECT {rejfile} '
-            '--WARN_ON_MISSING_CONTIG true'
+            f'{self.picard} LiftoverVcf -I={infile} -O={tmpfile} -CHAIN={chain} -R={refgen} -REJECT={rejfile} '
+            '--WARN_ON_MISSING_CONTIG=true'
         )
         # need to change 'chr' notation depending on liftover direction
         c = chromosome if not ch else f'chr{chromosome}'

--- a/src/hatchet/utils/run.py
+++ b/src/hatchet/utils/run.py
@@ -158,8 +158,8 @@ def main(args=None):
                 f'{output}/phase/',
                 '-L',
             ]
-            + (['-N'] if config.genotype_snps.chr_notation else [])
             + glob.glob(f'{output}/snps/*.vcf.gz')
+            + (['-N'] if config.genotype_snps.chr_notation else [])
             + extra_args
         )
 


### PR DESCRIPTION
Dear Hatchet developers, 
I spotted two issues when running the last version of Hatchet, and I suggest two solutions. 

- The SNP argument when calling phase_snps() is swapped with the chromosome annotation and this causes an error. Sorting it properly fixest the issue.

- When installing Hatchet through conda, it also installs picard. This breaks the Liftover commands, which pressumably were using an old picard.jar file on your side. The fixes allowed Hatchet to move forward in the phasing bit.

Hope this helps.

Oriol