### PR TITLE
Vb/bcftools

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -75,17 +75,17 @@ jobs:
 
       - name: Install SAMtools
         run: |
-          wget https://sourceforge.net/projects/samtools/files/samtools/1.7/samtools-1.7.tar.bz2/download -O samtools-1.7.tar.bz2
-          tar xvjf samtools-1.7.tar.bz2
-          (cd samtools-1.7 && ./configure && make)
-          echo "HATCHET_PATHS_SAMTOOLS=$(realpath samtools-1.7)" >> $GITHUB_ENV
+          wget https://sourceforge.net/projects/samtools/files/samtools/1.11/samtools-1.11.tar.bz2/download -O samtools-1.11.tar.bz2
+          tar xvjf samtools-1.11.tar.bz2
+          (cd samtools-1.11 && ./configure && make)
+          echo "HATCHET_PATHS_SAMTOOLS=$(realpath samtools-1.11)" >> $GITHUB_ENV
 
       - name: Install BCFTools
         run: |
-          wget https://sourceforge.net/projects/samtools/files/samtools/1.7/bcftools-1.7.tar.bz2/download -O bcftools-1.7.tar.bz2
-          tar xvjf bcftools-1.7.tar.bz2
-          (cd bcftools-1.7 && ./configure && make)
-          echo "HATCHET_PATHS_BCFTOOLS=$(realpath bcftools-1.7)" >> $GITHUB_ENV
+          wget https://sourceforge.net/projects/samtools/files/samtools/1.11/bcftools-1.11.tar.bz2/download -O bcftools-1.11.tar.bz2
+          tar xvjf bcftools-1.11.tar.bz2
+          (cd bcftools-1.11 && ./configure && make)
+          echo "HATCHET_PATHS_BCFTOOLS=$(realpath bcftools-1.11)" >> $GITHUB_ENV
 
       - name: Install tabix
         run: |

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "hatchet"
-version = "1.0.3"
+version = "1.0.4"
 authors = [
   { name="Simone Zaccaria", email="s.zaccaria@ucl.ac.uk" },
   { name="Ben Raphael", email="braphael@cs.princeton.edu" },

--- a/src/hatchet/__init__.py
+++ b/src/hatchet/__init__.py
@@ -1,4 +1,4 @@
-__version__ = '1.0.3'
+__version__ = '1.0.4'
 
 import os.path
 from importlib.resources import path


### PR DESCRIPTION
`bcftools` is used in a specific use case in `genotype_snps`:
```
bcftools query -f <format> -r <region> <remote_vcf_gz>
```
This only seems to work with `bcftools>1.11` (looks like older versions can't handle the `-r` flag with remote vcf files because they insist on the index first).

This check should invoke `bcftools` with something similar to this use case.
The `bioconda` recipe for `HATCHet` should be modified to need `bcftools>=1.11`