### PR TITLE
Bug fix in count_alleles; Fix to run demo end-end on specific chromosome(s)

### DIFF
--- a/docs/source/doc_count_alleles.md
+++ b/docs/source/doc_count_alleles.md
@@ -21,7 +21,7 @@ count-alleles produces three tab-separated files: the first contains the read co
 |------|-------------|--------|
 | `-O`, `--outputnormal` | The output file for the read counts from matched-normal sample | `#SAMPLE  CHR  POS  REF_COUNT  ALT_COUNT` |
 | `-o`, `--outputtumors` | The output file for the read counts from the tumor samples | `#SAMPLE  CHR  POS  REF_COUNT  ALT_COUNT` |
-| `-l`, `--outputsnps` | the output file for the list of identified heterozygous germline SNPs | `#CHR POS` |
+| `-l`, `--outputsnps` | the output directory for the list of identified heterozygous germline SNPs | `#CHR POS` |
 
 The format fields are described in the following.
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "hatchet"
-version = "1.0.3"
+version = "1.1.0"
 authors = [
   { name="Simone Zaccaria", email="s.zaccaria@ucl.ac.uk" },
   { name="Ben Raphael", email="braphael@cs.princeton.edu" },

--- a/script/README.md
+++ b/script/README.md
@@ -31,7 +31,7 @@ As an example, this should be set to `chr22` for [HATCHet Demo data](https://zen
 To run the pipeline on all chromosomes, leave the key blank.
 
 ```
-chromosomes = 
+chromosomes =
 ```
 
 ## Run HATCHet without phasing

--- a/script/README.md
+++ b/script/README.md
@@ -9,7 +9,7 @@ will use `hatchet.ini` in the writeup below.
 ## Set variables
 
 Set all variables in `hatchet.ini` with appropriate values. You will likely not need to modify anything at all other
-than the paths to the reference genome, paths to the the normal and tumor bam files, and unique names for the tumor
+than the paths to the reference genome, paths to the normal and tumor bam files, and unique names for the tumor
 samples, all in the `run` section of `hatchet.ini`:
 
 ```
@@ -17,6 +17,21 @@ reference = "/path/to/reference.fa"
 normal = "/path/to/normal.bam"
 bams = "/path/to/tumor1.bam /path/to/tumor2.bam"
 samples = "Primary Met"
+```
+
+Optionally, if you wish to run the HATCHet pipeline only on select chromosome(s), specify their name(s) under the
+'chromosomes' key, separated by whitespace. For example:
+
+```
+chromosomes = chr21 chr22
+```
+
+This can be very useful when trying to validate your pipeline relatively quickly before running it on all chromosomes.
+As an example, this should be set to `chr22` for [HATCHet Demo data](https://zenodo.org/record/4046906).
+To run the pipeline on all chromosomes, leave the key blank.
+
+```
+chromosomes = 
 ```
 
 ## Run HATCHet without phasing

--- a/script/hatchet.ini
+++ b/script/hatchet.ini
@@ -1,73 +1,77 @@
 [run]
 # What individual steps of HATCHet should we run in the pipeline?
 # Valid values are True or False
-download_panel=True
-count_reads=True
-genotype_snps=True
-phase_snps=True
-fixed_width=False # True uses older fixed-width versions of some commands
-count_alleles=True
-combine_counts=True
-cluster_bins=True
-loc_clust=True # True uses new locality-aware clustering
-plot_bins=True
-compute_cn=True
-plot_cn=True
+download_panel = True
+count_reads = True
+genotype_snps = True
+phase_snps = True
+fixed_width = False  # True uses older fixed-width versions of some commands
+count_alleles = True
+combine_counts = True
+cluster_bins = True
+loc_clust = True  # True uses new locality-aware clustering
+plot_bins = True
+compute_cn = True
+plot_cn = True
+
+# What chromosome(s) do we wish to process in the pipeline? Leave unspecified to process
+# all chromosomes found in the normal/tumor bam files
+chromosomes =
 
 # Path to reference genome
 # Make sure you have also generated the reference dictionary as /path/to/reference.dict
-reference = "/path/to/reference.fa"
+reference = /path/to/reference.fa
 
 # Make sure you have generated the .bam.bai files at the same locations as these bam files
-normal = "/path/to/normal.bam"
+normal = /path/to/normal.bam
 
 # Space-delimited list of tumor BAM locations
-bams = "/path/to/tumor1.bam /path/to/tumor2.bam"
+bams = /path/to/tumor1.bam /path/to/tumor2.bam
 
 # Space-delimited list of tumor names
-samples = "tumor1 tumor2"
+samples = tumor1 tumor2
 
 # Output path of the run script
-output = "output/"
+output = output/
 
 # How many cores to use for the end-end pipeline?
 # This parameter, if specified, will override corresponding 'processes' parameters in individual <step> sections below.
 processes = 6
 
 [download_panel]
-ref_panel = "1000GP_Phase3"
-refpaneldir = "/path/to/reference/panel"
+ref_panel = 1000GP_Phase3
+refpaneldir = /path/to/reference/panel
 
 [genotype_snps]
 # Reference version used to select list of known germline SNPs;
 # Possible values are "hg19" or "hg38", or leave blank "" if you wish for all positions to be genotyped by bcftools
-reference_version = "hg19"
+reference_version = hg19
 # Does your reference name chromosomes with "chr" prefix?; True or False
-chr_notation = False
+chr_notation = True
 
 # Use 8 for WGS with >30x and 20 for WES with ~100x
 mincov = 8
 # Use 300 for WGS with >30x and Use 1000 for WES with ~100x
 maxcov = 300
 # Path to SNP list
-#   If None, HATCHet selects a list of known germline SNPs based on <run.reference_version> and <run.chr_notation>
+#   If unspecified, HATCHet selects a list of known germline SNPs based on <run.reference_version> and <run.chr_notation>
 #   If not, please provide full path to a locally stored list (.vcf.gz) here.
-snps = None
+snps =
 
 [combine_counts]
 # Minimum number of SNP-covering reads per bin and sample
-msr=5000
+msr = 5000
 # Minimum number of total reads per bin and sample
-mtr=5000
+mtr = 5000
 
 [cluster_bins_loc]
-diploidbaf=0.08
+diploidbaf = 0.08
 # Minimum and maximum number of clusters to infer
 # (using silhouette score for model selection)
-minK=2
-maxK=30
+minK = 2
+maxK = 30
 # You can instead specify an exact number of clusters:
-# exactK=15
+# exactK = 15
 
 [plot_bins]
 sizethreshold = 0.01

--- a/src/hatchet/__init__.py
+++ b/src/hatchet/__init__.py
@@ -1,4 +1,4 @@
-__version__ = '1.0.3'
+__version__ = '1.1.0'
 
 import os.path
 from importlib.resources import path

--- a/src/hatchet/utils/ArgParsing.py
+++ b/src/hatchet/utils/ArgParsing.py
@@ -517,6 +517,11 @@ def parse_count_reads_args(args=None):
         default=config.count_reads.intermediates,
         help='Produce intermediate counts files only and do not proceed to forming arrays (default: False)',
     )
+    parser.add_argument(
+        '--chromosomes',
+        required=False,
+        help='Comma separated chromosomes to process (default: blank to process all chromosomes)',
+    )
 
     args = parser.parse_args(args)
 
@@ -545,6 +550,8 @@ def parse_count_reads_args(args=None):
 
     # Extract the names of the chromosomes and check their consistency across the given BAM files and the reference
     chromosomes = extractChromosomes(samtools, [bams[0], 'normal'], [(x, '') for x in bams[1:]])
+    if args.chromosomes is not None:
+        chromosomes = [c for c in chromosomes if c in args.chromosomes]
 
     # Check that chr notation is consistent across chromosomes
     using_chr = [a.startswith('chr') for a in chromosomes]
@@ -916,6 +923,11 @@ def parse_genotype_snps_arguments(args=None):
         help='Output folder for SNPs separated by chromosome (default: ./)',
     )
     parser.add_argument(
+        '--chromosomes',
+        required=False,
+        help='Comma separated chromosomes to process (default: blank to process all chromosomes)',
+    )
+    parser.add_argument(
         '-v',
         '--verbose',
         action='store_true',
@@ -961,6 +973,8 @@ def parse_genotype_snps_arguments(args=None):
 
     # Extract the names of the chromosomes and check their consistency across the given BAM files and the reference
     chromosomes = extractChromosomes(samtools, normal, [], args.reference)
+    if args.chromosomes is not None:
+        chromosomes = [c for c in chromosomes if c in args.chromosomes]
 
     ensure(
         args.processes > 0,
@@ -1379,6 +1393,11 @@ def parse_count_alleles_arguments(args=None):
         help='Output directory for lists of selected SNPs (default: ./)',
     )
     parser.add_argument(
+        '--chromosomes',
+        required=False,
+        help='Comma separated chromosomes to process (default: blank to process all chromosomes)',
+    )
+    parser.add_argument(
         '-v',
         '--verbose',
         action='store_true',
@@ -1435,6 +1454,8 @@ def parse_count_alleles_arguments(args=None):
 
     # Extract the names of the chromosomes and check their consistency across the given BAM files and the reference
     chromosomes = extractChromosomes(samtools, normal, samples, args.reference)
+    if args.chromosomes is not None:
+        chromosomes = [c for c in chromosomes if c in args.chromosomes]
     snplists = {c: snplists.get(c, []) for c in chromosomes}
 
     ensure(
@@ -1610,6 +1631,11 @@ def parse_count_reads_fw_arguments(args=None):
         required=False,
         help='Use verbose log messages',
     )
+    parser.add_argument(
+        '--chromosomes',
+        required=False,
+        help='Comma separated chromosomes to process (default: blank to process all chromosomes)',
+    )
     parser.add_argument('-V', '--version', action='version', version=f'%(prog)s {__version__}')
     args = parser.parse_args(args)
 
@@ -1689,6 +1715,8 @@ def parse_count_reads_fw_arguments(args=None):
 
     # Extract the names of the chromosomes and check their consistency across the given BAM files and the reference
     chromosomes = extractChromosomes(samtools, normal, samples)
+    if args.chromosomes is not None:
+        chromosomes = [c for c in chromosomes if c in args.chromosomes]
 
     ensure(
         args.processes > 0,

--- a/src/hatchet/utils/count_alleles.py
+++ b/src/hatchet/utils/count_alleles.py
@@ -191,7 +191,7 @@ def counting(
     )
 
     results = worker.run(work=work, n_instances=num_workers)
-    results = {(v[0][0], v[0][1]): v for v in results}
+    results = {(v[0][0], v[0][1]): v for v in results if v}
     return results
 
 
@@ -221,9 +221,7 @@ class AlleleCounter(Worker):
         self.outdir = outdir
 
     def work(self, bamfile, samplename, chromosome):
-        # return 42
-        snps = self.countAlleles(bamfile=bamfile, samplename=samplename, chromosome=chromosome)
-        return snps
+        return self.countAlleles(bamfile=bamfile, samplename=samplename, chromosome=chromosome)
 
     def countAlleles(self, bamfile, samplename, chromosome):
         cmd_mpileup = '{} mpileup {} -Ou -f {} --skip-indels -a INFO/AD -q {} -Q {} -d {} -T {}'.format(

--- a/src/hatchet/utils/plot_bins_1d2d.py
+++ b/src/hatchet/utils/plot_bins_1d2d.py
@@ -163,7 +163,7 @@ def plot_1d(
     chrlengths = {str(c): df.END.max() for c, df in bbc.groupby('#CHR')}
     chr_ends = [0]
     for i in range(22):
-        chr_ends.append(chr_ends[-1] + chrlengths[f'chr{i + 1}'])
+        chr_ends.append(chr_ends[-1] + chrlengths.get(f'chr{i + 1}', 0))
 
     np.random.seed(0)
     flips = np.random.randint(2, size=len(bbc))

--- a/src/hatchet/utils/plot_cn_1d2d.py
+++ b/src/hatchet/utils/plot_cn_1d2d.py
@@ -72,7 +72,7 @@ def generate_1D2D_plots(
     chrlengths = {str(c): df.END.max() for c, df in bbc.groupby('#CHR')}
     chr_ends = [0]
     for i in range(22):
-        chr_ends.append(chr_ends[-1] + chrlengths[f'chr{i + 1}'])
+        chr_ends.append(chr_ends[-1] + chrlengths.get(f'chr{i + 1}', 0))
 
     n_clones = max([i for i in range(MAX_CLONES) if f'cn_clone{i}' in bbc.columns])
     _, mapping = reindex([k for k, _ in bbc.groupby([f'cn_clone{i + 1}' for i in range(n_clones)])])

--- a/src/hatchet/utils/run.py
+++ b/src/hatchet/utils/run.py
@@ -123,7 +123,7 @@ def main(args=None):
                 '-o',
                 f'{output}/snps/',
                 '--chromosomes',
-                chromosomes
+                chromosomes,
             ]
             + extra_args
         )
@@ -187,7 +187,7 @@ def main(args=None):
                 '-l',
                 f'{output}',
                 '--chromosome',
-                chromosomes
+                chromosomes,
             ]
             + extra_args
         )
@@ -212,7 +212,7 @@ def main(args=None):
                     '-O',
                     f'{output}/rdr',
                     '--chromosomes',
-                    chromosomes
+                    chromosomes,
                 ]
                 + extra_args
             )
@@ -278,8 +278,8 @@ def main(args=None):
                     '-t',
                     f'{output}/rdr/total.tsv',
                     '--chromosomes',
-                    chromosomes
-            ]
+                    chromosomes,
+                ]
                 + extra_args
             )
 

--- a/src/hatchet/utils/run.py
+++ b/src/hatchet/utils/run.py
@@ -35,6 +35,11 @@ def main(args=None):
     output = output.rstrip('/')
     os.makedirs(output, exist_ok=True)
 
+    try:
+        chromosomes = [c for c in config.run.chromosomes.split()]
+    except (KeyError, AttributeError):  # if key is absent or is blank (None)
+        chromosomes = None  # process all
+
     extra_args = []
     try:
         if config.run.processes is not None:
@@ -117,6 +122,8 @@ def main(args=None):
                 snps,
                 '-o',
                 f'{output}/snps/',
+                '--chromosomes',
+                chromosomes
             ]
             + extra_args
         )
@@ -145,7 +152,6 @@ def main(args=None):
             )
 
         os.makedirs(f'{output}/phase', exist_ok=True)
-        args
         phase_snps(
             args=[
                 '-D',
@@ -180,6 +186,8 @@ def main(args=None):
                 f'{output}/baf/tumor.1bed',
                 '-l',
                 f'{output}',
+                '--chromosome',
+                chromosomes
             ]
             + extra_args
         )
@@ -203,6 +211,8 @@ def main(args=None):
                     f'{output}/baf/tumor.1bed',
                     '-O',
                     f'{output}/rdr',
+                    '--chromosomes',
+                    chromosomes
                 ]
                 + extra_args
             )
@@ -267,7 +277,9 @@ def main(args=None):
                     f'{output}/rdr/tumor.1bed',
                     '-t',
                     f'{output}/rdr/total.tsv',
-                ]
+                    '--chromosomes',
+                    chromosomes
+            ]
                 + extra_args
             )
 


### PR DESCRIPTION
This PR fixes issues #150 and #153.

Currently the HATCHet demo (which only has data for `chr22`) is incapable of running end-end, since (among possibly other things), the `genotype_snps` step is not programmed to handle the case where no snps are found (as would be the case for all chromosomes in the demo except `chr22`):

https://github.com/raphael-group/hatchet/blob/03fe4ccc4d02c521bfc56f9be7b9fc9c6d16b779/src/hatchet/utils/genotype_snps.py#L63

The introduction of a `chromosomes` key in the `run` section (optional to keep the code backward compatible) as is done in this PR allows end-end processing to happen correctly when it is set to `chr22`. This key is added to relevant steps in the pipeline by `run.py` as follows:

`download_panel` -> not added; The entire panel is downloaded/indexed, regardless of downstream processing.
`genotype_snps` -> added
`phase_snps` -> not added, since -L/--snps is used directly (List of SNPs in the normal sample to phase)
`count_alleles` -> added
`count_reads` -> added
`count_reads_fw` -> added
`combine_counts` -> not added, since -A/--array is used directly (Directory containing array files (output from "count_reads" command))
`cluster_bins/cluster_bins_gmm` -> not added, since BBFILE is used directly (A BB file containing a line for each bin in each sample and the corresponding values of read-depth ratio and B-allele frequency (BAF))
`plot_bins` -> not added, since INPUT is used directly (Input BBC file with RDR and BAF)
`compute_cn` -> not passed, since --input is used directly (Prefix path to seg and bbc input files )
`plot_cn/plot_cn1d2d` -> not added, since INPUT is used directly. (One or more space-separated files in CN_BBC format)