### PR TITLE
Bug fix for issue #163

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "hatchet"
-version = "1.1.1"
+version = "1.1.2"
 authors = [
   { name="Simone Zaccaria", email="s.zaccaria@ucl.ac.uk" },
   { name="Ben Raphael", email="braphael@cs.princeton.edu" },

--- a/src/hatchet/__init__.py
+++ b/src/hatchet/__init__.py
@@ -1,4 +1,4 @@
-__version__ = '1.1.1'
+__version__ = '1.1.2'
 
 import os.path
 from importlib.resources import path

--- a/src/hatchet/utils/ArgParsing.py
+++ b/src/hatchet/utils/ArgParsing.py
@@ -520,7 +520,8 @@ def parse_count_reads_args(args=None):
     parser.add_argument(
         '--chromosomes',
         required=False,
-        help='Comma separated chromosomes to process (default: blank to process all chromosomes)',
+        nargs='*',
+        help='One or more chromosomes to process (default: blank to process all chromosomes)',
     )
 
     args = parser.parse_args(args)
@@ -550,7 +551,7 @@ def parse_count_reads_args(args=None):
 
     # Extract the names of the chromosomes and check their consistency across the given BAM files and the reference
     chromosomes = extractChromosomes(samtools, [bams[0], 'normal'], [(x, '') for x in bams[1:]])
-    if args.chromosomes is not None:
+    if args.chromosomes:
         chromosomes = [c for c in chromosomes if c in args.chromosomes]
 
     # Check that chr notation is consistent across chromosomes
@@ -925,7 +926,8 @@ def parse_genotype_snps_arguments(args=None):
     parser.add_argument(
         '--chromosomes',
         required=False,
-        help='Comma separated chromosomes to process (default: blank to process all chromosomes)',
+        nargs='*',
+        help='One or more chromosomes to process (default: blank to process all chromosomes)',
     )
     parser.add_argument(
         '-v',
@@ -973,7 +975,7 @@ def parse_genotype_snps_arguments(args=None):
 
     # Extract the names of the chromosomes and check their consistency across the given BAM files and the reference
     chromosomes = extractChromosomes(samtools, normal, [], args.reference)
-    if args.chromosomes is not None:
+    if args.chromosomes:
         chromosomes = [c for c in chromosomes if c in args.chromosomes]
 
     ensure(
@@ -1395,7 +1397,8 @@ def parse_count_alleles_arguments(args=None):
     parser.add_argument(
         '--chromosomes',
         required=False,
-        help='Comma separated chromosomes to process (default: blank to process all chromosomes)',
+        nargs='*',
+        help='One or more chromosomes to process (default: blank to process all chromosomes)',
     )
     parser.add_argument(
         '-v',
@@ -1454,7 +1457,7 @@ def parse_count_alleles_arguments(args=None):
 
     # Extract the names of the chromosomes and check their consistency across the given BAM files and the reference
     chromosomes = extractChromosomes(samtools, normal, samples, args.reference)
-    if args.chromosomes is not None:
+    if args.chromosomes:
         chromosomes = [c for c in chromosomes if c in args.chromosomes]
     snplists = {c: snplists.get(c, []) for c in chromosomes}
 
@@ -1634,7 +1637,8 @@ def parse_count_reads_fw_arguments(args=None):
     parser.add_argument(
         '--chromosomes',
         required=False,
-        help='Comma separated chromosomes to process (default: blank to process all chromosomes)',
+        nargs='*',
+        help='One or more chromosomes to process (default: blank to process all chromosomes)',
     )
     parser.add_argument('-V', '--version', action='version', version=f'%(prog)s {__version__}')
     args = parser.parse_args(args)
@@ -1715,7 +1719,7 @@ def parse_count_reads_fw_arguments(args=None):
 
     # Extract the names of the chromosomes and check their consistency across the given BAM files and the reference
     chromosomes = extractChromosomes(samtools, normal, samples)
-    if args.chromosomes is not None:
+    if args.chromosomes:
         chromosomes = [c for c in chromosomes if c in args.chromosomes]
 
     ensure(

--- a/src/hatchet/utils/run.py
+++ b/src/hatchet/utils/run.py
@@ -38,7 +38,7 @@ def main(args=None):
     try:
         chromosomes = [c for c in config.run.chromosomes.split()]
     except (KeyError, AttributeError):  # if key is absent or is blank (None)
-        chromosomes = None  # process all
+        chromosomes = []  # process all
 
     extra_args = []
     try:
@@ -123,8 +123,8 @@ def main(args=None):
                 '-o',
                 f'{output}/snps/',
                 '--chromosomes',
-                chromosomes,
             ]
+            + (chromosomes or [])  # important to keep this as a list here to allow proper argparse parsing
             + extra_args
         )
 
@@ -186,9 +186,9 @@ def main(args=None):
                 f'{output}/baf/tumor.1bed',
                 '-l',
                 f'{output}',
-                '--chromosome',
-                chromosomes,
+                '--chromosomes',
             ]
+            + (chromosomes or [])  # important to keep this as a list here to allow proper argparse parsing
             + extra_args
         )
 
@@ -212,8 +212,8 @@ def main(args=None):
                     '-O',
                     f'{output}/rdr',
                     '--chromosomes',
-                    chromosomes,
                 ]
+                + (chromosomes or [])  # important to keep this as a list here to allow proper argparse parsing
                 + extra_args
             )
 
@@ -277,9 +277,9 @@ def main(args=None):
                     f'{output}/rdr/tumor.1bed',
                     '-t',
                     f'{output}/rdr/total.tsv',
-                    '--chromosomes',
-                    chromosomes,
+                    '--chromosomes'
                 ]
+                + (chromosomes or [])  # important to keep this as a list here to allow proper argparse parsing
                 + extra_args
             )
 

--- a/src/hatchet/utils/run.py
+++ b/src/hatchet/utils/run.py
@@ -277,7 +277,7 @@ def main(args=None):
                     f'{output}/rdr/tumor.1bed',
                     '-t',
                     f'{output}/rdr/total.tsv',
-                    '--chromosomes'
+                    '--chromosomes',
                 ]
                 + (chromosomes or [])  # important to keep this as a list here to allow proper argparse parsing
                 + extra_args


### PR DESCRIPTION
Bug fix for issue #163. Parsing `--chromosomes` on the command line for `HATCHet` commands that do support the flag would not have worked before (to generate a proper list to pass on to the internal chromosome filtering logic).