### PR TITLE
pandas groupby depreciation fix

### DIFF
--- a/src/hatchet/utils/plot_cn_1d2d.py
+++ b/src/hatchet/utils/plot_cn_1d2d.py
@@ -390,7 +390,7 @@ def plot_genome(
                     )
 
             if n_clones == 1:
-                my_colors = [cmap(mapping[r]) for r in bbc.cn_clone1]
+                my_colors = [cmap(mapping[tuple([r])]) for r in bbc.cn_clone1]
             else:
                 my_colors = [
                     cmap(mapping[tuple(r)]) for _, r in bbc[[f'cn_clone{i + 1}' for i in range(n_clones)]].iterrows()
@@ -523,7 +523,7 @@ def plot_clusters(
         assert n_clones2 == n_clones, (n_clones2, n_clones)
 
         if n_clones == 1:
-            my_colors = [cmap(mapping[r]) for r in bbc_.cn_clone1]
+            my_colors = [cmap(mapping[tuple([r])]) for r in bbc_.cn_clone1]
         else:
             my_colors = [
                 cmap(mapping[tuple(r)]) for _, r in bbc_[[f'cn_clone{i + 1}' for i in range(n_clones)]].iterrows()


### PR DESCRIPTION
This is a fix for the FutureWarning on the pandas groupby call on [line 78](https://github.com/raphael-group/hatchet/blob/944893c19bc4abc1ab520a0c710098f974bb1c9f/src/hatchet/utils/plot_cn_1d2d.py#L78)

"FutureWarning: FutureWarning: In a future version of pandas, a length 1 tuple will be returned when iterating over a groupby with a grouper equal to a list of length 1. Don't supply a list with a single grouper to avoid this warning."