### PR TITLE
user can input purity values

### DIFF
--- a/src/hatchet/hatchet.ini
+++ b/src/hatchet/hatchet.ini
@@ -216,6 +216,8 @@ compute_cn = False
 plot_cn = False
 loc_clust = True
 
+purities = None
+
 [urls]
 onekgp = https://mathgen.stats.ox.ac.uk/impute/1000GP_Phase3.tgz
 refpanel_genome = http://hgdownload.cse.ucsc.edu/goldenPath/hg19/bigZips/hg19.fa.gz

--- a/src/hatchet/utils/ArgParsing.py
+++ b/src/hatchet/utils/ArgParsing.py
@@ -403,7 +403,10 @@ def parse_cluster_bins_args(args=None):
     )
     ensure(args.restarts >= 1, 'Number of restarts must be positive.')
     ensure(args.tau >= 0, 'Transition parameter --tau must be non-negative.')
-    ensure(args.tau >= 6e-17, 'Transition parameter --tau must be at least 6e-17 to ensure numerical precision.')
+    ensure(
+        args.tau >= 6e-17,
+        'Transition parameter --tau must be at least 6e-17 to ensure numerical precision.',
+    )
 
     if args.subset is not None:
         import pandas as pd
@@ -553,12 +556,15 @@ def parse_count_reads_args(args=None):
     # Parse BAM files, check their existence, and infer or parse the corresponding sample names
     bams = [args.normal] + args.tumor
     for bamfile in bams:
-        ensure(isfile(bamfile), 'The specified tumor BAM file does not exist')
+        ensure(
+            isfile(bamfile),
+            f'The specified tumor BAM file {bamfile} does not exist',
+        )
     # also make sure the bam index files are present too
     for bamfile in bams:
         ensure(
             isfile(bamfile + '.bai') or isfile(bamfile.replace('.bam', '.bai')),
-            'The specified tumor BAM file does not exist',
+            f'The specified tumor BAM file {bamfile} does not have an index file (bai)',
         )
     names = args.samples
     ensure(
@@ -757,7 +763,10 @@ def parse_combine_counts_args(args=None):
     args = parser.parse_args(args)
 
     ensure(os.path.exists(args.baffile), f'BAF file not found: {args.baffile}')
-    ensure(os.path.exists(args.referencefasta), f'Reference genome fasta file file not found: {args.referencefasta}')
+    ensure(
+        os.path.exists(args.referencefasta),
+        f'Reference genome fasta file file not found: {args.referencefasta}',
+    )
     if args.totalcounts is not None and not isfile(args.totalcounts):
         raise ValueError(error('The specified file for total read counts does not exist!'))
     ensure(

--- a/src/hatchet/utils/check_solver.py
+++ b/src/hatchet/utils/check_solver.py
@@ -19,6 +19,7 @@ def main(args=None):
         with tempfile.TemporaryDirectory() as tempdirname:
             with path(hatchet.data, 'sample.bbc') as bbc_path:
                 input_files_prefix = os.path.splitext(bbc_path)[0]
+                # purity values are free
                 hatchet_main(
                     args=[
                         '-x',
@@ -46,6 +47,38 @@ def main(args=None):
                         '0.35',
                         '-l',
                         '0.6',
+                    ]
+                )
+                # purity values are fixed
+                hatchet_main(
+                    args=[
+                        '-x',
+                        os.path.join(tempdirname),
+                        '-i',
+                        input_files_prefix,
+                        '-n2',
+                        '-p',
+                        '5',
+                        '-v',
+                        '3',
+                        '-u',
+                        '0.03',
+                        '--mode',
+                        '0',
+                        '-r',
+                        '6700',
+                        '-j',
+                        '1',
+                        '-eD',
+                        '6',
+                        '-eT',
+                        '12',
+                        '-g',
+                        '0.35',
+                        '-l',
+                        '0.6',
+                        '-P',
+                        '0.6 0.2 0',
                     ]
                 )
 

--- a/src/hatchet/utils/solve/__init__.py
+++ b/src/hatchet/utils/solve/__init__.py
@@ -38,6 +38,7 @@ def solve(
     max_iters=None,
     timelimit=None,
     binwise=False,
+    purities=None,
 ):
 
     assert solve_mode in ('ilp', 'cd', 'both'), 'Unrecognized solve_mode'
@@ -101,6 +102,7 @@ def solve(
                 f_a=f_a,
                 f_b=f_b,
                 w=weights,
+                purities=purities,
             )
             ilp.create_model(pprint=True)
             return ilp.run(solver_type=solver, timelimit=timelimit)
@@ -115,6 +117,7 @@ def solve(
                 w=weights,
                 ampdel=ampdel,
                 cn=copy_numbers,
+                purities=purities,
             )
             return cd.run(
                 solver_type=solver,
@@ -135,6 +138,7 @@ def solve(
                 w=weights,
                 ampdel=ampdel,
                 cn=copy_numbers,
+                purities=purities,
             )
             _, cA, cB, _, _, _ = cd.run(
                 solver_type=solver,
@@ -155,6 +159,7 @@ def solve(
                 f_a=f_a,
                 f_b=f_b,
                 w=weights,
+                purities=purities,
             )
             ilp.create_model()
             ilp.hot_start(cA, cB)
@@ -216,6 +221,7 @@ def solve(
                 binsA=binsA,
                 binsB=binsB,
                 lengths=bins_length,
+                purities=purities,
             )
             ilp.create_model(pprint=True)
             return ilp.run(solver_type=solver, timelimit=timelimit)

--- a/src/hatchet/utils/solve/cd.py
+++ b/src/hatchet/utils/solve/cd.py
@@ -68,7 +68,7 @@ def _work(cd, u, solver_type, max_iters, max_convergence_iters, timelimit):
 
 
 class CoordinateDescent:
-    def __init__(self, f_a, f_b, n, mu, d, cn_max, cn, w, ampdel=True):
+    def __init__(self, f_a, f_b, n, mu, d, cn_max, cn, w, purities, ampdel=True):
         # ilp attribute used here as a convenient storage container for properties
         self.ilp = ILPSubset(
             n=n,
@@ -80,6 +80,7 @@ class CoordinateDescent:
             f_a=f_a,
             f_b=f_b,
             w=w,
+            purities=purities,
         )
         # Building the model here is not strictly necessary, as, during execution,
         #   self.carch and c.uarch will copy self.ilp and create+run those models.


### PR DESCRIPTION
- I added a config file parameter purities. It takes a space-separated list of float values.  The value in the i'th position sets the purity value of the i'th sample. The length of the list must be equal to the number of samples.
- I added a case to `hatchet check` command. The case tests user fixing the purity.
- When a sample file is the missing index file, HATCHet now prints an informative error message.
