### PR TITLE
Convert string `None` to Python None

### DIFF
--- a/src/hatchet/utils/ArgParsing.py
+++ b/src/hatchet/utils/ArgParsing.py
@@ -784,6 +784,9 @@ def parse_combine_counts_args(args=None):
     )
     if args.totalcounts is not None and not isfile(args.totalcounts):
         raise ValueError(error('The specified file for total read counts does not exist!'))
+
+    if args.phase == 'None':
+        args.phase = None
     ensure(
         (args.phase is None) or isfile(args.phase),
         'The specified phasing file does not exist!',


### PR DESCRIPTION
# Description

As described in #208, it appears that the conversion of the string "None" to the python None object wasn't implemented in the `parse_combine_counts_args` function unlike the ‎`parse_combine_counts_fw_args`‎ function. This results in the error shown in #208. Therefore, it seems that the `phase_snps` step is not treated as optional when `fixed_width = False`.

### Closes #208 

## Testing Results

When 
```
[combine_counts]
# Path to phased file; leave as "None" to run hatchet without phasing
phase = "None"
```
It successfully passed check without failing.
```
NO PHASING FILE FOUND at /path/phased.vcf.gz. Not including phasing in binning process.
[2024-May-01 21:28:51]# Parsing and checking input arguments
````

@mmyers1 @balabanmetin Please let me know if you want me to run additional tests. 