### PR TITLE
fix type incompatible bug when nochr is used

### DIFF
--- a/src/hatchet/utils/rd_gccorrect.py
+++ b/src/hatchet/utils/rd_gccorrect.py
@@ -28,8 +28,8 @@ def rd_gccorrect(bb, ref_genome):
                 "3_usercol": "END",
                 "5_pct_gc": "GC",
             }
-        ).astype({"#CHR": str}
-        )[["#CHR", "START", "END", "GC"]]
+        )
+        .astype({"#CHR": str})[["#CHR", "START", "END", "GC"]]
     )
 
     # Correcting GC bias per sample

--- a/src/hatchet/utils/rd_gccorrect.py
+++ b/src/hatchet/utils/rd_gccorrect.py
@@ -28,6 +28,7 @@ def rd_gccorrect(bb, ref_genome):
                 "3_usercol": "END",
                 "5_pct_gc": "GC",
             }
+        ).astype({"#CHR": str}
         )[["#CHR", "START", "END", "GC"]]
     )
 


### PR DESCRIPTION
`combin_counts.py` always use `str` type for `#CHR`, as shown below.
https://github.com/raphael-group/hatchet/blob/3729a359287f6683cb1649f8321cf70f40b7045e/src/hatchet/utils/combine_counts.py#L110-L112

When `nochr` is enabled (reference/bam file doesn't have `chr` prefix), `to_dataframe()` in `rd_gccorrect.py` will automatically use `int64` dtype for column `#CHR`, which is incompatible with `#CHR` from dataframe `bb`, as shown below and from the issue #236.
https://github.com/raphael-group/hatchet/blob/3729a359287f6683cb1649f8321cf70f40b7045e/src/hatchet/utils/rd_gccorrect.py#L20-L32

This fix converts the dtype of `#CHR` to `str` post `to_dataframe()`.