### PR TITLE
Plot fixes, filename centralization, and pre-release option lockout

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -47,7 +47,7 @@ jobs:
 
       # --no-build-isolation compiles _hmm_cpp against the conda toolchain
       # (pybind11, cxx-compiler, and the platform OpenMP) instead of a PyPI copy.
-      - name: Build and install HATCHet3 with test extra
+      - name: Build and install HATCHet with test extra
         run: pip install --no-build-isolation ".[test]"
 
       - name: Report backend and solvers

--- a/.gitignore
+++ b/.gitignore
@@ -205,7 +205,7 @@ cython_debug/
 #  that can be found at https://github.com/github/gitignore/blob/main/Global/VisualStudioCode.gitignore
 #  and can be added to the global gitignore or merged into this file. However, if you prefer, 
 #  you could uncomment the following to ignore the entire vscode folder
-# .vscode/
+.vscode/
 
 # Ruff stuff:
 .ruff_cache/

--- a/config/snakemake-hatchet.yaml
+++ b/config/snakemake-hatchet.yaml
@@ -1,5 +1,5 @@
 ##################################################
-# HATCHet3 Snakmake YAML configuration file
+# HATCHet Snakmake YAML configuration file
 #
 # See docs/reference.md for full descriptions
 ##################################################
@@ -30,7 +30,7 @@ cluster-bins:
 compute-cn:
   # cluster-bins K to use: null = model-selected bulk.bbc/seg, or an int for labels/bulk<k>
   k: null
-  # solver mode: ilp | cd | both | cnt_cd
+  # solver mode: ilp | cd | both
   mode: cd
   diploid: true
   tetraploid: true

--- a/docs/modules/compute-cn.md
+++ b/docs/modules/compute-cn.md
@@ -10,9 +10,9 @@ The BBC and SEG tables produced by `cluster-bins` (`--bbc`, `--seg`; e.g. `bbc/b
 ```console
 $ hatchet compute-cn --help
 usage: hatchet compute-cn [-h] --result_dir RESULT_DIR --bbc BBC --seg SEG
-                          [--mode {both,cd,ilp,cnt_cd}]
-                          [--model_select {elbow,bic}] [--force]
-                          [--solver {gurobi,cbc}] [--timelimit TIMELIMIT]
+                          [--mode {both,cd,ilp}] [--model_select {elbow,bic}]
+                          [--force] [--solver {gurobi,cbc}]
+                          [--timelimit TIMELIMIT]
                           [--fcn_ci_alpha FCN_CI_ALPHA]
                           [--min_ci_margin MIN_CI_MARGIN]
                           [--obj_type {imf,ci}] [--minClone MINCLONE]
@@ -27,11 +27,9 @@ usage: hatchet compute-cn [-h] --result_dir RESULT_DIR --bbc BBC --seg SEG
                           [--cd_niters CD_NITERS]
                           [--cd_convergence_iters CD_CONVERGENCE_ITERS]
                           [--cd_nseeds CD_NSEEDS] [--cd_njobs CD_NJOBS]
-                          [--cd_seed CD_SEED]
-                          [--u_init {dirichlet,bubble,bin_dir}]
-                          [--u_dir_alpha U_DIR_ALPHA] [--u_bin_p U_BIN_P]
+                          [--cd_seed CD_SEED] [--u_init {dirichlet,bubble}]
+                          [--u_dir_alpha U_DIR_ALPHA]
                           [--solver_threads SOLVER_THREADS]
-                          [--tree_file TREE_FILE] [--eps_fit EPS_FIT]
                           [--verbosity VERBOSITY] --genome_size GENOME_SIZE
                           --region_bed REGION_BED [--patient_id PATIENT_ID]
 ```

--- a/docs/reference.md
+++ b/docs/reference.md
@@ -90,7 +90,7 @@ Defaults below are the CLI defaults from `hatchet_parser.py`. Use
 | `--result_dir` | *(required)* | Output directory for computed CN results |
 | `--genome_size` | *(required)* | Reference chromosome sizes file |
 | `--region_bed` | *(required)* | Reference chromosome BED file |
-| `--mode` | `cd` | Solver mode: `cd`, `ilp`, `both`, or `cnt_cd` (**Experimental**) |
+| `--mode` | `cd` | Solver mode: `cd`, `ilp`, or `both` |
 | `--solver` | `gurobi` | ILP solver backend: `gurobi` or `cbc` |
 | `--model_select` | `bic` | Clone-number/ploidy selection: `elbow` or `bic` |
 | `--force` | False | Re-solve even if results already exist (default: skip existing) |
@@ -120,12 +120,9 @@ Defaults below are the CLI defaults from `hatchet_parser.py`. Use
 | `--cd_nseeds` | 400 | CD: number of random restarts |
 | `--cd_njobs` | 8 | CD: number of parallel worker processes |
 | `--cd_seed` | 42 | CD: random seed for reproducibility |
-| `--u_init` | `dirichlet` | U initialization: `dirichlet`, `bubble`, or `bin_dir` |
+| `--u_init` | `dirichlet` | U initialization: `dirichlet` or `bubble` |
 | `--u_dir_alpha` | *(solver default)* | Dirichlet alpha for U initialization; lower = sparser |
-| `--u_bin_p` | *(solver default)* | `bin_dir`: per-cell Bernoulli presence probability |
 | `--solver_threads` | *(solver default)* | Max threads per solver call (Gurobi); set to 1 for parallel CD workers |
-| `--tree_file` | None | **Experimental** (`cnt_cd`): Newick tree file; if omitted, enumerate all unlabeled shapes |
-| `--eps_fit` | 0.01 | **Experimental** (`cnt_cd`): fit tolerance for the C-step CNT lexicographic bound |
 | `--plot_ascn` | False | Plot CN profile with the allele-CN row scheme |
 | `--patient_id` | `panel` | Output filename prefix for per-(ploidy, n) plots |
 | `--verbosity` | 0 | Verbose level: 0, 1, or 2 |

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -6,7 +6,7 @@ build-backend = "setuptools.build_meta"
 name = "hatchet"
 dynamic = ["version"]
 requires-python = ">=3.11"
-description = "HATCHet3: Holistic Allele-specific Tumor Copy-number Heterogeneity"
+description = "HATCHet: Holistic Allele-specific Tumor Copy-number Heterogeneity"
 license = "BSD-3-Clause"
 license-files = ["LICENSE"]
 dependencies = [

--- a/scripts/liftover_cnp.py
+++ b/scripts/liftover_cnp.py
@@ -7,7 +7,7 @@ import pandas as pd
 from scripts_utils import read_seg_ucn_file
 
 """
-Liftover HATCHet3 copy-number profile seg.ucn/bbc.ucn to different reference version
+Liftover HATCHet copy-number profile seg.ucn/bbc.ucn to different reference version
 """
 
 

--- a/src/hatchet/cluster_bins/cluster_bins.py
+++ b/src/hatchet/cluster_bins/cluster_bins.py
@@ -42,6 +42,7 @@ from hatchet.cluster_bins.hmm.hmm_model import (
     score_model,
 )
 from hatchet.plot.plot_cluster_bins import plot_rdr_baf
+from hatchet.plot.plot_utils import get_plot_style
 
 
 def run(args=None):
@@ -69,6 +70,8 @@ def run(args=None):
     setup_logging(args)
     logging.info("cluster bins")
     _log_done = log_step_start()
+
+    plot_style = get_plot_style(args)
 
     bb_dir = args["bb_dir"]
     bb_file = os.path.join(bb_dir, "bb.tsv.gz")
@@ -203,7 +206,7 @@ def run(args=None):
         ylab="RDR",
         out_dir=plot_dir,
         out_prefix="raw_",
-        dpi=100,
+        style=plot_style,
     )
 
     baf_taus0 = np.zeros(ntumor_samples, dtype=np.float32)
@@ -502,13 +505,13 @@ def run(args=None):
             ylab="RDR",
             out_dir=plot_dir,
             out_prefix=f"K{K}_",
-            dpi=100,
             rdr_means=k_rdr_means,
             rdr_vars=k_rdr_vars,
             baf_taus=k_baf_taus,
             log_rdr=log_rdr,
             filtered_ids=filtered_ids,
             balanced_ids=balanced_ids,
+            style=plot_style,
         )
 
         bbs["PHASE"] = k_phases

--- a/src/hatchet/cluster_bins/cluster_bins.py
+++ b/src/hatchet/cluster_bins/cluster_bins.py
@@ -13,6 +13,7 @@ from hatchet.utils import (
     setup_logging,
 )
 from hatchet.io_utils import read_genome_sizes, read_sample_file
+from hatchet import filenames as fn
 from hatchet.cluster_bins.cluster_utils import (
     compute_baf_se,
     compute_rdr_se,
@@ -74,13 +75,13 @@ def run(args=None):
     plot_style = get_plot_style(args)
 
     bb_dir = args["bb_dir"]
-    bb_file = os.path.join(bb_dir, "bb.tsv.gz")
-    sample_file = os.path.join(bb_dir, "sample_ids.tsv")
-    rdr_mfile = os.path.join(bb_dir, "bb.rdr.npz")
-    depth_mfile = os.path.join(bb_dir, "bb.depth.npz")
-    a_mfile = os.path.join(bb_dir, "bb.Aallele.npz")
-    b_mfile = os.path.join(bb_dir, "bb.Ballele.npz")
-    t_mfile = os.path.join(bb_dir, "bb.Tallele.npz")
+    bb_file = os.path.join(bb_dir, fn.BB_TSV_GZ)
+    sample_file = os.path.join(bb_dir, fn.SAMPLE_IDS)
+    rdr_mfile = os.path.join(bb_dir, fn.BB_RDR_NPZ)
+    depth_mfile = os.path.join(bb_dir, fn.BB_DEPTH_NPZ)
+    a_mfile = os.path.join(bb_dir, fn.BB_A_ALLELE_NPZ)
+    b_mfile = os.path.join(bb_dir, fn.BB_B_ALLELE_NPZ)
+    t_mfile = os.path.join(bb_dir, fn.BB_T_ALLELE_NPZ)
     genome_size = args["genome_size"]
     region_bed = args["region_bed"]
     out_dir = args["bbc_dir"]
@@ -88,13 +89,13 @@ def run(args=None):
     add_file_logging(out_dir, "cluster-bins")
     log_arguments(args)
 
-    out_bbc = os.path.join(out_dir, "bulk.bbc")
-    out_seg = os.path.join(out_dir, "bulk.seg")
+    out_bbc = os.path.join(out_dir, fn.BULK_BBC)
+    out_seg = os.path.join(out_dir, fn.BULK_SEG)
     if not args["force"] and os.path.exists(out_bbc) and os.path.exists(out_seg):
         logging.info(
             f"skip cluster-bins: {out_bbc} and {out_seg} already exist (use --force to re-run)"
         )
-        _log_done("cluster-bins", out_file=os.path.join(out_dir, "runtime.log"))
+        _log_done("cluster-bins", out_file=os.path.join(out_dir, fn.RUNTIME_LOG))
         return
 
     min_tau = args["min_tau"]
@@ -124,8 +125,8 @@ def run(args=None):
     training_method = args["training_method"]
     baf_k_start = 0 if args["free_baf_c0"] else 1
 
-    label_dir = os.path.join(out_dir, "labels")
-    plot_dir = os.path.join(out_dir, "plots")
+    label_dir = os.path.join(out_dir, fn.LABELS_DIR)
+    plot_dir = os.path.join(out_dir, fn.PLOTS_DIR)
     os.makedirs(label_dir, exist_ok=True)
     os.makedirs(plot_dir, exist_ok=True)
 
@@ -281,7 +282,7 @@ def run(args=None):
         inits_maxK,
         ntumor_samples,
         maxK,
-        os.path.join(plot_dir, "hmm_init.pdf"),
+        os.path.join(plot_dir, fn.HMM_INIT_PDF),
         baf_taus=baf_taus0,
         log_rdr=log_rdr,
         bbs=bbs,
@@ -298,7 +299,7 @@ def run(args=None):
     inits_run = dict(sorted_inits[:top_restarts])
 
     if DEBUG and inits_diag:
-        init_diag_dir = os.path.join(plot_dir, "init_diag")
+        init_diag_dir = os.path.join(plot_dir, fn.INIT_DIAG_DIR)
         os.makedirs(init_diag_dir, exist_ok=True)
         for it in inits_run:
             diag = inits_diag[it]
@@ -394,10 +395,10 @@ def run(args=None):
         elbo_data.append((K, all_elbo_traces, best_it))
 
         # Save EM parameter trace for best restart
-        trace_dir = os.path.join(out_dir, "traces")
+        trace_dir = os.path.join(out_dir, fn.TRACES_DIR)
         os.makedirs(trace_dir, exist_ok=True)
         np.savez_compressed(
-            os.path.join(trace_dir, f"K{K}.em_trace.npz"),
+            os.path.join(trace_dir, fn.k_em_trace(K)),
             elbo_trace=np.array(best_sol["elbo_trace"]),
             rdr_means=best_sol["trace_rdr_means"],
             rdr_vars=best_sol["trace_rdr_vars"],
@@ -517,7 +518,7 @@ def run(args=None):
         bbs["PHASE"] = k_phases
         bbs["PHASE_POSTS"] = best_sol["phase_posts"][:, 1]
         bbs[["#CHR", "START", "END", "PHASE", "PHASE_POSTS", "switchprobs"]].to_csv(
-            os.path.join(label_dir, f"bulk{K}.bb.phased.tsv.gz"),
+            os.path.join(label_dir, fn.bulk_k_phased(K)),
             sep="\t",
             header=True,
             index=False,
@@ -543,19 +544,19 @@ def run(args=None):
         k_segs["is_balanced"] = k_segs["#ID"].isin(balanced_ids)
         k_segs["is_filtered"] = k_segs["#ID"].isin(filtered_ids)
         bbcs.to_csv(
-            os.path.join(label_dir, f"bulk{K}.bbc"),
+            os.path.join(label_dir, fn.bulk_k_bbc(K)),
             sep="\t",
             header=True,
             index=False,
         )
         k_segs.to_csv(
-            os.path.join(label_dir, f"bulk{K}.seg"),
+            os.path.join(label_dir, fn.bulk_k_seg(K)),
             sep="\t",
             header=True,
             index=False,
         )
 
-    plot_elbo_traces(elbo_data, os.path.join(plot_dir, "elbo_traces.pdf"))
+    plot_elbo_traces(elbo_data, os.path.join(plot_dir, fn.ELBO_TRACES_PDF))
 
     scores_df = pd.DataFrame(score_records)
     best_K = model_select_K(scores_df, score_criteria, score_method)
@@ -563,24 +564,27 @@ def run(args=None):
     logging.info(
         f"model selection ({score_criteria}): best K={best_K} {score_method}={best_score:.4f}"
     )
-    scores_df.to_csv(os.path.join(out_dir, "model_scores.tsv"), sep="\t", index=False)
-    plot_score(scores_df, score_method, os.path.join(plot_dir, "model_scores.pdf"))
+    scores_df.to_csv(os.path.join(out_dir, fn.MODEL_SCORES_TSV), sep="\t", index=False)
+    plot_score(scores_df, score_method, os.path.join(plot_dir, fn.MODEL_SCORES_PDF))
 
     ##################################################
     # copy best-K results to top-level output
-    for suffix in ["bbc", "seg"]:
+    for src_name, dst_name in (
+        (fn.bulk_k_bbc(best_K), fn.BULK_BBC),
+        (fn.bulk_k_seg(best_K), fn.BULK_SEG),
+    ):
         shutil.copy2(
-            os.path.join(label_dir, f"bulk{best_K}.{suffix}"),
-            os.path.join(out_dir, f"bulk.{suffix}"),
+            os.path.join(label_dir, src_name),
+            os.path.join(out_dir, dst_name),
         )
     shutil.copy2(
-        os.path.join(label_dir, f"bulk{best_K}.bb.phased.tsv.gz"),
-        os.path.join(out_dir, "bb.phased.tsv.gz"),
+        os.path.join(label_dir, fn.bulk_k_phased(best_K)),
+        os.path.join(out_dir, fn.BB_PHASED_TSV_GZ),
     )
     shutil.copy2(
-        os.path.join(plot_dir, f"K{best_K}.pdf"),
-        os.path.join(out_dir, f"bulk.K{best_K}.pdf"),
+        os.path.join(plot_dir, fn.k_plot(best_K)),
+        os.path.join(out_dir, fn.bulk_k_plot(best_K)),
     )
 
-    _log_done("cluster-bins", out_file=os.path.join(out_dir, "runtime.log"))
+    _log_done("cluster-bins", out_file=os.path.join(out_dir, fn.RUNTIME_LOG))
     return

--- a/src/hatchet/cluster_bins/hmm/hmm_init_utils.py
+++ b/src/hatchet/cluster_bins/hmm/hmm_init_utils.py
@@ -12,6 +12,7 @@ from matplotlib.backends.backend_pdf import PdfPages
 from adjustText import adjust_text
 
 from hatchet.utils import sort_chroms
+from hatchet import filenames as fn
 
 logging.getLogger("adjustText").setLevel(logging.WARNING)
 
@@ -86,7 +87,7 @@ def plot_init_sampling_probs(
         bar_width = (bin_edges_1d[1] - bin_edges_1d[0]) * 0.9
         rdr_ylim_1d = float(np.nanpercentile(X_rdrs, 99)) * 1.1
 
-    out = os.path.join(plot_dir, f"{name}_init.pdf")
+    out = os.path.join(plot_dir, fn.init_pdf(name))
     pdf_pages = PdfPages(out)
     prev_summed = None
 

--- a/src/hatchet/compute_cn/compute_cn.py
+++ b/src/hatchet/compute_cn/compute_cn.py
@@ -372,7 +372,6 @@ def solve(
             timelimit=timelimit,
             tree_file=args["tree_file"],
             u_dir_alpha=args["u_dir_alpha"],
-            u_bin_p=args["u_bin_p"],
             solver_threads=args["solver_threads"],
             u0_tsv_path=u0_tsv_path,
         )
@@ -385,7 +384,6 @@ def solve(
             reg_bound=args["reg_bound"],
             u_init_method=args["u_init"],
             u_dir_alpha=args["u_dir_alpha"],
-            u_bin_p=args["u_bin_p"],
             solver_threads=args["solver_threads"],
             cd_tol=args["cd_tol"],
             **cd_run_kwargs,

--- a/src/hatchet/compute_cn/compute_cn.py
+++ b/src/hatchet/compute_cn/compute_cn.py
@@ -20,8 +20,6 @@ from hatchet.compute_cn.compute_cn_utils import (
     build_data,
     compute_fractional_cn,
     load_pool_from_disk,
-    plot_pareto_pdf,
-    run_plot_cn,
     segmentation,
 )
 from hatchet.compute_cn.model_select import (
@@ -35,7 +33,12 @@ from hatchet.compute_cn.solve.inference import (
     run_full_ilp,
     run_coordinate_descent,
 )
-from hatchet.plot.plot_compute_cn import plot_pool_cnp, plot_scaling_2d
+from hatchet.plot.plot_compute_cn import (
+    plot_pareto_curve,
+    plot_pool_cnp,
+    plot_scaling_2d,
+    run_plot_cn,
+)
 
 
 def run(args=None):
@@ -224,7 +227,7 @@ def run(args=None):
         segs,
         method=args["model_select"],
     )
-    plot_pareto_pdf(summary_df, plot_dir, args["reg_term"], elbow_fig)
+    plot_pareto_curve(summary_df, plot_dir, args["reg_term"], elbow_fig)
 
     # Write chosen per-ploidy
     for ploidy, n in chosen_n.items():

--- a/src/hatchet/compute_cn/compute_cn.py
+++ b/src/hatchet/compute_cn/compute_cn.py
@@ -12,6 +12,7 @@ from hatchet.utils import (
     setup_logging,
 )
 from hatchet.io_utils import read_bbc_file
+from hatchet import filenames as fn
 from hatchet.compute_cn.compute_cn_utils import (
     store_gammas,
     store_solve_input,
@@ -53,8 +54,8 @@ def run(args=None):
     os.makedirs(out_dir, exist_ok=True)
     add_file_logging(out_dir, "compute-cn")
     log_arguments(args)
-    plot_dir = os.path.join(out_dir, "plots")
-    sols_dir = os.path.join(out_dir, "sols")
+    plot_dir = os.path.join(out_dir, fn.PLOTS_DIR)
+    sols_dir = os.path.join(out_dir, fn.SOLS_DIR)
     os.makedirs(plot_dir, exist_ok=True)
     os.makedirs(sols_dir, exist_ok=True)
 
@@ -79,11 +80,11 @@ def run(args=None):
         maxcn=args["diploidcmax"],
         maxcn_wgd=args["tetraploidcmax"],
     )
-    gamma_outfile = os.path.join(out_dir, "gammas.tsv")
+    gamma_outfile = os.path.join(out_dir, fn.GAMMAS)
     store_gammas(gamma_outfile, scaling, samples)
 
     plot_scaling_2d(
-        samples, bbcs, segs, scaling, os.path.join(plot_dir, "scaling_2d.pdf")
+        samples, bbcs, segs, scaling, os.path.join(plot_dir, fn.SCALING_2D_PDF)
     )
 
     solve_mode = args["mode"]
@@ -121,14 +122,14 @@ def run(args=None):
             min_ci_margin=args["min_ci_margin"],
         )
         store_solve_input(
-            os.path.join(out_dir, "sols", f"solver_input.{ploidy}.tsv"),
+            os.path.join(out_dir, fn.SOLS_DIR, fn.solver_input(ploidy)),
             fcn_data,
         )
 
         for n in range(minClone, maxClone):
-            out_bbc = os.path.join(out_dir, f"results.{ploidy}.n{n}.bbc.ucn.tsv")
-            out_seg = os.path.join(out_dir, f"results.{ploidy}.n{n}.seg.ucn.tsv")
-            sol_dir = os.path.join(out_dir, f"sols/{ploidy}_n{n}")
+            out_bbc = os.path.join(out_dir, fn.results_bbc_ucn(ploidy, n))
+            out_seg = os.path.join(out_dir, fn.results_seg_ucn(ploidy, n))
+            sol_dir = os.path.join(out_dir, fn.SOLS_DIR, fn.ploidy_n_subdir(ploidy, n))
             if (
                 not args["force"]
                 and os.path.exists(out_bbc)
@@ -184,7 +185,7 @@ def run(args=None):
                 )
 
             pid = args["patient_id"] or "panel"
-            nplot_dir = os.path.join(plot_dir, f"{ploidy}_n{n}")
+            nplot_dir = os.path.join(plot_dir, fn.ploidy_n_subdir(ploidy, n))
             run_plot_cn(
                 args,
                 out_bbc,
@@ -205,7 +206,7 @@ def run(args=None):
                 title=f"{ploidy} n={n}",
                 solve_mode=solve_mode,
                 sample_names=fcn_data["sample_ids"],
-                out_name=f"{pid}.pool_{ploidy}_n{n}.pdf",
+                out_name=fn.pool_pdf(pid, ploidy, n),
             )
 
     if obj_dfs:
@@ -216,7 +217,7 @@ def run(args=None):
         if model_selection_df
         else pd.DataFrame()
     )
-    summary_path = os.path.join(out_dir, "summary.tsv")
+    summary_path = os.path.join(out_dir, fn.SUMMARY_TSV)
     summary_df.to_csv(summary_path, sep="\t", index=False)
     logging.info(f"wrote {summary_path} ({len(summary_df)} solutions)")
 
@@ -232,28 +233,28 @@ def run(args=None):
     # Write chosen per-ploidy
     for ploidy, n in chosen_n.items():
         shutil.copy2(
-            os.path.join(out_dir, f"results.{ploidy}.n{n}.bbc.ucn.tsv"),
-            os.path.join(out_dir, f"chosen.{ploidy}.bbc.ucn"),
+            os.path.join(out_dir, fn.results_bbc_ucn(ploidy, n)),
+            os.path.join(out_dir, fn.chosen_bbc_ucn(ploidy)),
         )
         shutil.copy2(
-            os.path.join(out_dir, f"results.{ploidy}.n{n}.seg.ucn.tsv"),
-            os.path.join(out_dir, f"chosen.{ploidy}.seg.ucn"),
+            os.path.join(out_dir, fn.results_seg_ucn(ploidy, n)),
+            os.path.join(out_dir, fn.chosen_seg_ucn(ploidy)),
         )
         logging.info(
-            f"chosen {ploidy} n={n}: {os.path.join(out_dir, f'chosen.{ploidy}.bbc.ucn')}"
+            f"chosen {ploidy} n={n}: {os.path.join(out_dir, fn.chosen_bbc_ucn(ploidy))}"
         )
 
     # Write best (across ploidies)
     shutil.copy2(
-        os.path.join(out_dir, f"chosen.{best_ploidy}.bbc.ucn"),
-        os.path.join(out_dir, "best.bbc.ucn"),
+        os.path.join(out_dir, fn.chosen_bbc_ucn(best_ploidy)),
+        os.path.join(out_dir, fn.BEST_BBC_UCN),
     )
     shutil.copy2(
-        os.path.join(out_dir, f"chosen.{best_ploidy}.seg.ucn"),
-        os.path.join(out_dir, "best.seg.ucn"),
+        os.path.join(out_dir, fn.chosen_seg_ucn(best_ploidy)),
+        os.path.join(out_dir, fn.BEST_SEG_UCN),
     )
     logging.info(f"model-selected: {best_ploidy} n={best_n}")
-    _log_done("compute-cn", out_file=os.path.join(out_dir, "runtime.log"))
+    _log_done("compute-cn", out_file=os.path.join(out_dir, fn.RUNTIME_LOG))
 
 
 def solve(
@@ -299,7 +300,9 @@ def solve(
 
     cd_instances = None
     pool_instances = {}
-    u0_tsv_path = os.path.join(sol_dir, "u0_seeds.tsv") if sol_dir is not None else None
+    u0_tsv_path = (
+        os.path.join(sol_dir, fn.U0_SEEDS_TSV) if sol_dir is not None else None
+    )
     cd_run_kwargs = dict(
         solver_type=solver_type,
         max_iters=args["cd_niters"],

--- a/src/hatchet/compute_cn/compute_cn_utils.py
+++ b/src/hatchet/compute_cn/compute_cn_utils.py
@@ -7,6 +7,7 @@ import numpy as np
 
 from hatchet.utils import build_seg_from_bbc
 from hatchet.io_utils import read_region_bed
+from hatchet import filenames as fn
 
 
 # === Data preparation ===
@@ -288,7 +289,7 @@ def store_instance_tofile(pool_instances, input_data, sol_dir, solve_mode):
     header = "\t".join(cols)
 
     for sol_id, sol in pool_instances.items():
-        path = os.path.join(sol_dir, f"{solve_mode}_{sol_id}.tsv")
+        path = os.path.join(sol_dir, fn.solution_tsv(solve_mode, sol_id))
         with open(path, "w") as fd:
             _write_solution_tsv(
                 fd,
@@ -307,7 +308,7 @@ def store_instance_tofile(pool_instances, input_data, sol_dir, solve_mode):
 
             tree = sol.get("tree")
             if tree is not None and isinstance(tree, LabeledCloneTree):
-                prefix = os.path.join(sol_dir, f"{solve_mode}_{sol_id}")
+                prefix = os.path.join(sol_dir, fn.solution_stem(solve_mode, sol_id))
                 with open(f"{prefix}.nwk", "w") as f:
                     f.write(tree.to_newick() + "\n")
                 d = tree.to_dict()
@@ -328,7 +329,7 @@ def update_objectives_tsv(sols_dir, new_df):
     """
     cols = ["ploidy", "n", "sol_id", "restart_id", "imf_obj", "reg_obj"]
     new_df = new_df[cols]
-    path = os.path.join(sols_dir, "objectives.tsv")
+    path = os.path.join(sols_dir, fn.OBJECTIVES_TSV)
     if os.path.exists(path):
         old = pd.read_csv(path, sep="\t")
         keys = set(map(tuple, new_df[["ploidy", "n"]].itertuples(index=False)))
@@ -345,7 +346,7 @@ def load_pool_from_disk(sol_dir, cluster_ids, sample_ids):
     sol_id is taken, matching how the pool selects its representative at solve time.
     """
     ploidy, _, n = os.path.basename(sol_dir.rstrip("/")).rpartition("_n")
-    obj_path = os.path.join(os.path.dirname(sol_dir.rstrip("/")), "objectives.tsv")
+    obj_path = os.path.join(os.path.dirname(sol_dir.rstrip("/")), fn.OBJECTIVES_TSV)
     obj_map = {}
     if os.path.exists(obj_path) and ploidy:
         odf = pd.read_csv(obj_path, sep="\t")

--- a/src/hatchet/compute_cn/compute_cn_utils.py
+++ b/src/hatchet/compute_cn/compute_cn_utils.py
@@ -7,26 +7,9 @@ import numpy as np
 
 from hatchet.utils import build_seg_from_bbc
 from hatchet.io_utils import read_region_bed
-from hatchet.plot import plot_cn as _plot_cn
 
 
-def store_gammas(out_file, scaling, samples):
-    """Write per-sample gamma values for all ploidies.
-
-    Args:
-        out_file: output TSV path.
-        scaling: dict from get_scaling_factor with 'diploid', 'tetraploid' keys.
-        samples: ordered sample list.
-    """
-    with open(out_file, "w") as fd:
-        for sample in samples:
-            g_dip = scaling["diploid"]["gammas"].get(sample, 0)
-            g_tet = (
-                scaling["tetraploid"]["gammas"].get(sample, 0)
-                if scaling["tetraploid"]
-                else 0
-            )
-            fd.write(f"{sample}\t{g_dip}\t{g_tet}\n")
+# === Data preparation ===
 
 
 def build_data(bbcs, segs, segment=False):
@@ -156,100 +139,65 @@ def build_data(bbcs, segs, segment=False):
     }
 
 
-def filtering(
-    bbc: pd.DataFrame,
-    seg: pd.DataFrame,
-    samples: list,
-    clusters: list,
-    fstd=2.0,
-    min_nbins=10,
-    ub_nbins=50,
-):
-    """Filter clusters before the optimization step using variance outlier detection.
+def compute_fractional_cn(input_data, gammas, alpha=0.05, min_ci_margin=0.1):
+    """Compute fractional copy numbers and CI.
 
-    Steps:
-        0. Remove any cluster with fewer than ``min_nbins`` bins.
-        1. Compute per-sample, per-cluster RD and BAF variance (SCV).
-        2. Compute per-sample mean variance (MV) and standard deviation (STDV)
-           across clusters that passed step 0.
-        3. Mark a cluster as an outlier if, across all samples, its SCV deviates
-           from MV by more than ``fstd`` standard deviations, AND the cluster
-           has at most ``ub_nbins`` bins.
+    Returns a new dict containing all fields from input_data plus
+    fcn, fa, fb, fa_lo, fa_hi, fb_lo, fb_hi. input_data is not modified.
 
     Args:
-        bbc: Bin-level DataFrame with columns ``SAMPLE``, ``CLUSTER``, ``RD``, ``BAF``.
-        seg: Segment-level DataFrame with columns ``SAMPLE``, ``#ID``, ``RD``, ``BAF``,
-            ``#BINS``.
-        samples: Ordered list of sample identifiers.
-        clusters: Ordered list of cluster identifiers.
-        fstd: Number of standard deviations used as the outlier threshold.
-        min_nbins: Clusters with fewer bins than this are always removed.
-        ub_nbins: Outlier detection only applies to clusters with at most this
-            many bins (large clusters are kept regardless of variance).
-
-    Returns:
-        A tuple ``(good_clusters, bad_clusters)`` where each element is a list
-        of cluster IDs.
+        input_data: dict from build_data with rdr, baf, rdr_se.
+        gammas: dict or Series of per-sample gamma values.
+        alpha: significance level (default 0.05 → 95% CI).
+        min_ci_margin: hard minimum CI half-width in FCN space.
     """
-    logging.info("preprocessing, filtering clusters")
+    from scipy.stats import norm
 
-    var_rd_matrix = np.zeros((len(clusters), len(samples)), dtype=np.float64)
-    var_baf_matrix = np.zeros((len(clusters), len(samples)), dtype=np.float64)
+    rdr = input_data["rdr"]
+    baf = input_data["baf"]
+    rdr_se = input_data["rdr_se"]
 
-    for i, cluster in enumerate(clusters):
-        for j, sample in enumerate(samples):
-            bbc_ = bbc[(bbc["SAMPLE"] == sample) & (bbc["CLUSTER"] == cluster)]
-            seg_ = seg[(seg["SAMPLE"] == sample) & (seg["#ID"] == cluster)]
-            seg_baf = seg_["BAF"].iloc[0]
-            seg_rdr = seg_["RD"].iloc[0]
-            var_rd_matrix[i, j] = np.linalg.norm(bbc_["RD"] - seg_rdr, 2) / len(bbc_)
-            var_baf_matrix[i, j] = np.linalg.norm(bbc_["BAF"] - seg_baf, 2) / len(bbc_)
+    gammas = pd.Series(gammas).sort_index()
+    fcn = rdr * gammas
+    fb = fcn * baf
+    fa = fcn - fb
 
-    cluster_filtered = np.zeros(len(clusters), dtype=bool)
-    for i, cluster in enumerate(clusters):
-        cluster_filtered[i] = seg[seg["#ID"] == cluster]["#BINS"].iloc[0] < min_nbins
+    z = norm.ppf(1 - alpha / 2)
+    margin_fa = np.maximum(z * gammas * (1 - baf) * rdr_se, min_ci_margin)
+    margin_fb = np.maximum(z * gammas * baf * rdr_se, min_ci_margin)
 
-    mv_rd = np.mean(var_rd_matrix[~cluster_filtered, :], axis=0)
-    stdv_rd = np.std(var_rd_matrix[~cluster_filtered, :], axis=0, ddof=1)
-    mv_baf = np.mean(var_baf_matrix[~cluster_filtered, :], axis=0)
-    stdv_baf = np.std(var_baf_matrix[~cluster_filtered, :], axis=0, ddof=1)
-    for j, sample in enumerate(samples):
-        lb_rd = mv_rd[j] - fstd * stdv_rd[j]
-        ub_rd = mv_rd[j] + fstd * stdv_rd[j]
-        lb_baf = mv_baf[j] - fstd * stdv_baf[j]
-        ub_baf = mv_baf[j] + fstd * stdv_baf[j]
-        logging.debug(
-            f"{sample} RD-var bound=({lb_rd:.6f}, {ub_rd:.6f}) BAF-var bound=({lb_baf:.6f}, {ub_baf:.6f})"
-        )
+    return {
+        **input_data,
+        "fcn": fcn,
+        "fa": fa,
+        "fb": fb,
+        "fa_lo": fa - margin_fa,
+        "fa_hi": fa + margin_fa,
+        "fb_lo": fb - margin_fb,
+        "fb_hi": fb + margin_fb,
+    }
 
-    good_clusters = []
-    bad_clusters = []
-    for i, cluster in enumerate(clusters):
-        nbins = seg[seg["#ID"] == cluster]["#BINS"].iloc[0]
-        dv_rd = np.abs(var_rd_matrix[i, :] - mv_rd)
-        dv_baf = np.abs(var_baf_matrix[i, :] - mv_baf)
-        z_rd = dv_rd / stdv_rd
-        z_baf = dv_baf / stdv_baf
-        is_outlier = (
-            np.all(dv_rd > (fstd * stdv_rd))
-            or np.all(dv_baf > (fstd * stdv_baf))
-            or cluster_filtered[i]
-        ) and (nbins <= ub_nbins)
-        status = "REMOVED" if is_outlier else "kept"
-        for j, sample in enumerate(samples):
-            logging.debug(
-                f"z={cluster} {sample} #bins={nbins} "
-                f"RD-var={var_rd_matrix[i, j]:.6f} Z(RD)={z_rd[j]:.4f} "
-                f"BAF-var={var_baf_matrix[i, j]:.6f} Z(BAF)={z_baf[j]:.4f} "
-                f"{status}"
+
+# === Solver input ===
+
+
+def store_gammas(out_file, scaling, samples):
+    """Write per-sample gamma values for all ploidies.
+
+    Args:
+        out_file: output TSV path.
+        scaling: dict from get_scaling_factor with 'diploid', 'tetraploid' keys.
+        samples: ordered sample list.
+    """
+    with open(out_file, "w") as fd:
+        for sample in samples:
+            g_dip = scaling["diploid"]["gammas"].get(sample, 0)
+            g_tet = (
+                scaling["tetraploid"]["gammas"].get(sample, 0)
+                if scaling["tetraploid"]
+                else 0
             )
-        if is_outlier:
-            bad_clusters.append(cluster)
-        else:
-            good_clusters.append(cluster)
-
-    logging.info(f"remaining clusters: {good_clusters}")
-    return good_clusters, bad_clusters
+            fd.write(f"{sample}\t{g_dip}\t{g_tet}\n")
 
 
 def store_solve_input(out_file, input_data):
@@ -268,6 +216,9 @@ def store_solve_input(out_file, input_data):
                 fd.write(
                     f"{cid}\t{sample}\t{nb}\t" + "\t".join(vals) + f"\t{weights[cid]}\n"
                 )
+
+
+# === Solution persistence ===
 
 
 def _write_solution_tsv(fd, input_data, cA, cB, u, n, cluster_ids, sample_ids, header):
@@ -386,228 +337,6 @@ def update_objectives_tsv(sols_dir, new_df):
     new_df.to_csv(path, sep="\t", index=False)
 
 
-def compute_fractional_cn(input_data, gammas, alpha=0.05, min_ci_margin=0.1):
-    """Compute fractional copy numbers and CI.
-
-    Returns a new dict containing all fields from input_data plus
-    fcn, fa, fb, fa_lo, fa_hi, fb_lo, fb_hi. input_data is not modified.
-
-    Args:
-        input_data: dict from build_data with rdr, baf, rdr_se.
-        gammas: dict or Series of per-sample gamma values.
-        alpha: significance level (default 0.05 → 95% CI).
-        min_ci_margin: hard minimum CI half-width in FCN space.
-    """
-    from scipy.stats import norm
-
-    rdr = input_data["rdr"]
-    baf = input_data["baf"]
-    rdr_se = input_data["rdr_se"]
-
-    gammas = pd.Series(gammas).sort_index()
-    fcn = rdr * gammas
-    fb = fcn * baf
-    fa = fcn - fb
-
-    z = norm.ppf(1 - alpha / 2)
-    margin_fa = np.maximum(z * gammas * (1 - baf) * rdr_se, min_ci_margin)
-    margin_fb = np.maximum(z * gammas * baf * rdr_se, min_ci_margin)
-
-    return {
-        **input_data,
-        "fcn": fcn,
-        "fa": fa,
-        "fb": fb,
-        "fa_lo": fa - margin_fa,
-        "fa_hi": fa + margin_fa,
-        "fb_lo": fb - margin_fb,
-        "fb_hi": fb + margin_fb,
-    }
-
-
-def segmentation(
-    cA,
-    cB,
-    u,
-    input_data: dict,
-    bbcs: pd.DataFrame,
-    region_file: str,
-    bbc_out_file=None,
-    seg_out_file=None,
-):
-    """Annotate bins with inferred CN states and build a segment-level DataFrame.
-
-    Args:
-        cA: (num_clusters, num_clones) allele-A CN.
-        cB: (num_clusters, num_clones) allele-B CN.
-        u: (num_clones, num_samples) clone proportions.
-        input_data: dict from build_data with cluster_ids, sample_ids.
-        bbcs: Bin-level DataFrame.
-        region_file: Path to region BED file.
-        bbc_out_file: If provided, write annotated bin-level TSV.
-        seg_out_file: If provided, write segment-level TSV.
-
-    Returns:
-        Segment-level DataFrame.
-    """
-    cluster_ids = input_data["cluster_ids"]
-    sample_ids = input_data["sample_ids"]
-    seg_to_cluster = input_data.get("seg_to_cluster")
-    df = bbcs.copy()
-
-    n_clone = len(cA[0])
-    cN = pd.DataFrame(
-        np.array(cA).astype(str) + "|" + np.array(cB).astype(str),
-        index=cluster_ids,
-        columns=["cn_normal"] + [f"cn_clone{i}" for i in range(1, n_clone)],
-    )
-    u_df = pd.DataFrame(u, index=range(n_clone), columns=sample_ids).T
-    u_df.columns = ["u_normal"] + [f"u_clone{i}" for i in range(1, n_clone)]
-    extra_columns = [col for pair in zip(cN.columns, u_df.columns) for col in pair]
-
-    if seg_to_cluster is not None:
-        # Segment mode: assign each bin its segment ID, merge CN by segment.
-        df = df.sort_values(["SAMPLE", "#CHR", "START", "END"]).reset_index(drop=True)
-        samples_sorted = sorted(df["SAMPLE"].unique())
-        first_mask = df["SAMPLE"] == samples_sorted[0]
-        first_df = df.loc[first_mask].reset_index(drop=True)
-        seg_boundary = (first_df["CLUSTER"] != first_df["CLUSTER"].shift()) | (
-            first_df["#CHR"] != first_df["#CHR"].shift()
-        )
-        seg_int = (seg_boundary.cumsum() - 1).values
-        df["_seg_int"] = np.tile(seg_int, len(samples_sorted))
-        # Map integer seg index to string seg ID (same logic as build_data)
-        seg_id_list = cluster_ids  # already in segment order
-        int_to_seg = {i: seg_id_list[i] for i in range(len(seg_id_list))}
-        df["_seg_id"] = df["_seg_int"].map(int_to_seg)
-        df = df.merge(cN, left_on="_seg_id", right_index=True)
-        df = df.drop(columns=["_seg_int", "_seg_id"])
-    else:
-        df = df.merge(cN, left_on="CLUSTER", right_index=True)
-
-    df = df.merge(u_df, left_on="SAMPLE", right_index=True)
-    df = df.sort_values(["#CHR", "START", "END", "SAMPLE"]).reset_index(drop=True)
-
-    if bbc_out_file is not None:
-        orig_cols = df.columns[: -2 * n_clone].tolist()
-        df[orig_cols + extra_columns].to_csv(bbc_out_file, sep="\t", index=False)
-
-    regions = read_region_bed(region_file)
-    seg_df = build_seg_from_bbc(df, regions)
-    if seg_out_file is not None:
-        seg_df.to_csv(seg_out_file, sep="\t", index=False)
-
-    return seg_df
-
-
-def run_plot_cn(args, bbc, seg, gamma_file, plot_dir, ploidy, name=None):
-    if not os.path.exists(bbc) or not os.path.exists(seg):
-        return
-    _plot_cn.run(
-        {
-            "bbc": bbc,
-            "seg": seg,
-            "genome_size": args["genome_size"],
-            "region_bed": args["region_bed"],
-            "gamma_file": gamma_file,
-            "solfile": None,
-            "patient_id": name,
-            "plot_dir": plot_dir,
-            "dpi": 150,
-            "img_type": "pdf",
-            "transparent": False,
-            "show_gap": False,
-            "tail_alpha": 0.8,
-            "center_alpha": 1.0,
-            "onetail_area": 0.025,
-            "maxlim_fcn": 30,
-            "ploidy": ploidy,
-        }
-    )
-
-
-def plot_pareto_pdf(summary_df, plot_dir, reg_term, elbow_fig=None):
-    """Plot REG vs IMF Pareto curves + elbow/BIC page as a multi-page PDF."""
-    import matplotlib.pyplot as plt
-    from matplotlib.backends.backend_pdf import PdfPages
-
-    outfile = os.path.join(plot_dir, "model_selection.pdf")
-    reg_col = reg_term if reg_term in summary_df.columns else "REG"
-    ploidies = sorted(summary_df["ploidy"].unique())
-    cmap = plt.get_cmap("tab10")
-
-    n_pages = 0
-    with PdfPages(outfile) as pdf:
-        # One page per ploidy; overlay all n-clone solutions, each n a distinct color.
-        for ploidy in ploidies:
-            pdf_grp = summary_df[summary_df["ploidy"] == ploidy]
-            ns = sorted(pdf_grp["n_clones"].unique())
-            fig, ax = plt.subplots(figsize=(7, 5))
-
-            # Non-pareto across all n: shared light-gray backdrop
-            non_pareto = pdf_grp[~pdf_grp["is_pareto"]]
-            if len(non_pareto) > 0:
-                ax.scatter(
-                    non_pareto[reg_col],
-                    non_pareto["IMF"],
-                    c="0.8",
-                    s=15,
-                    zorder=2,
-                    alpha=0.4,
-                    linewidths=0,
-                )
-
-            for ni, n_clones in enumerate(ns):
-                grp = pdf_grp[pdf_grp["n_clones"] == n_clones]
-                color = cmap(ni % 10)
-                pareto = grp[grp["is_pareto"]].sort_values(reg_col)
-                if len(pareto) > 0:
-                    ax.plot(
-                        pareto[reg_col],
-                        pareto["IMF"],
-                        "-o",
-                        color=color,
-                        markersize=5,
-                        linewidth=1.3,
-                        zorder=4,
-                        label=f"n={n_clones}",
-                    )
-                sel = grp[grp["selected"] == "*"]
-                if len(sel) > 0:
-                    ax.scatter(
-                        sel[reg_col],
-                        sel["IMF"],
-                        facecolors=color,
-                        marker="*",
-                        s=250,
-                        zorder=5,
-                        edgecolors="black",
-                        linewidths=1,
-                    )
-
-            ax.set_xlabel(reg_col, fontsize=11)
-            ax.set_ylabel("IMF", fontsize=11)
-            ax.set_title(
-                f"{ploidy} ({len(pdf_grp)} solutions)",
-                fontsize=13,
-                fontweight="bold",
-            )
-            ax.legend(fontsize=9, title="clones")
-            ax.grid(True, alpha=0.3)
-            fig.tight_layout()
-            pdf.savefig(fig)
-            plt.close(fig)
-            n_pages += 1
-
-        # Append elbow/BIC figure as last page
-        if elbow_fig is not None:
-            pdf.savefig(elbow_fig)
-            plt.close(elbow_fig)
-            n_pages += 1
-
-    logging.info(f"wrote {outfile} ({n_pages} pages)")
-
-
 def load_pool_from_disk(sol_dir, cluster_ids, sample_ids):
     """Read pool solution TSVs from sol_dir into {sol_id: {"imf_obj": ..., "cA": ..., ...}}.
 
@@ -683,3 +412,81 @@ def load_pool_from_disk(sol_dir, cluster_ids, sample_ids):
     if pool:
         logging.info(f"loaded {len(pool)} pool solutions from {sol_dir}")
     return pool
+
+
+# === Segmentation ===
+
+
+def segmentation(
+    cA,
+    cB,
+    u,
+    input_data: dict,
+    bbcs: pd.DataFrame,
+    region_file: str,
+    bbc_out_file=None,
+    seg_out_file=None,
+):
+    """Annotate bins with inferred CN states and build a segment-level DataFrame.
+
+    Args:
+        cA: (num_clusters, num_clones) allele-A CN.
+        cB: (num_clusters, num_clones) allele-B CN.
+        u: (num_clones, num_samples) clone proportions.
+        input_data: dict from build_data with cluster_ids, sample_ids.
+        bbcs: Bin-level DataFrame.
+        region_file: Path to region BED file.
+        bbc_out_file: If provided, write annotated bin-level TSV.
+        seg_out_file: If provided, write segment-level TSV.
+
+    Returns:
+        Segment-level DataFrame.
+    """
+    cluster_ids = input_data["cluster_ids"]
+    sample_ids = input_data["sample_ids"]
+    seg_to_cluster = input_data.get("seg_to_cluster")
+    df = bbcs.copy()
+
+    n_clone = len(cA[0])
+    cN = pd.DataFrame(
+        np.array(cA).astype(str) + "|" + np.array(cB).astype(str),
+        index=cluster_ids,
+        columns=["cn_normal"] + [f"cn_clone{i}" for i in range(1, n_clone)],
+    )
+    u_df = pd.DataFrame(u, index=range(n_clone), columns=sample_ids).T
+    u_df.columns = ["u_normal"] + [f"u_clone{i}" for i in range(1, n_clone)]
+    extra_columns = [col for pair in zip(cN.columns, u_df.columns) for col in pair]
+
+    if seg_to_cluster is not None:
+        # Segment mode: assign each bin its segment ID, merge CN by segment.
+        df = df.sort_values(["SAMPLE", "#CHR", "START", "END"]).reset_index(drop=True)
+        samples_sorted = sorted(df["SAMPLE"].unique())
+        first_mask = df["SAMPLE"] == samples_sorted[0]
+        first_df = df.loc[first_mask].reset_index(drop=True)
+        seg_boundary = (first_df["CLUSTER"] != first_df["CLUSTER"].shift()) | (
+            first_df["#CHR"] != first_df["#CHR"].shift()
+        )
+        seg_int = (seg_boundary.cumsum() - 1).values
+        df["_seg_int"] = np.tile(seg_int, len(samples_sorted))
+        # Map integer seg index to string seg ID (same logic as build_data)
+        seg_id_list = cluster_ids  # already in segment order
+        int_to_seg = {i: seg_id_list[i] for i in range(len(seg_id_list))}
+        df["_seg_id"] = df["_seg_int"].map(int_to_seg)
+        df = df.merge(cN, left_on="_seg_id", right_index=True)
+        df = df.drop(columns=["_seg_int", "_seg_id"])
+    else:
+        df = df.merge(cN, left_on="CLUSTER", right_index=True)
+
+    df = df.merge(u_df, left_on="SAMPLE", right_index=True)
+    df = df.sort_values(["#CHR", "START", "END", "SAMPLE"]).reset_index(drop=True)
+
+    if bbc_out_file is not None:
+        orig_cols = df.columns[: -2 * n_clone].tolist()
+        df[orig_cols + extra_columns].to_csv(bbc_out_file, sep="\t", index=False)
+
+    regions = read_region_bed(region_file)
+    seg_df = build_seg_from_bbc(df, regions)
+    if seg_out_file is not None:
+        seg_df.to_csv(seg_out_file, sep="\t", index=False)
+
+    return seg_df

--- a/src/hatchet/compute_cn/model_select.py
+++ b/src/hatchet/compute_cn/model_select.py
@@ -7,6 +7,8 @@ import pandas as pd
 import matplotlib.pyplot as plt
 from scipy.special import betaln, gammaln
 
+from hatchet import filenames as fn
+
 
 def _ll_gauss(obs_rdrs, exp_rdr, rdr_var, floor_var=1e-12):
     """Gaussian log-likelihood in RDR space with fixed variance."""
@@ -148,9 +150,7 @@ def model_selection_ploidy(
     def _compute_scores(ploidy):
         gammas = scaling[ploidy]["gammas"]
         ns_sorted = sorted(chosen_sols[ploidy].keys())
-        first_ucn = os.path.join(
-            out_dir, f"results.{ploidy}.n{ns_sorted[0]}.bbc.ucn.tsv"
-        )
+        first_ucn = os.path.join(out_dir, fn.results_bbc_ucn(ploidy, ns_sorted[0]))
         ll_n1, nobs_n1, n_clusters, n_samples = _compute_loglik_from_ucn(
             first_ucn, 1, gammas, segs
         )
@@ -159,7 +159,7 @@ def model_selection_ploidy(
         ns_all = [1] + ns_sorted
         lls = [ll_n1]
         for clone_n in ns_sorted:
-            ucn_file = os.path.join(out_dir, f"results.{ploidy}.n{clone_n}.bbc.ucn.tsv")
+            ucn_file = os.path.join(out_dir, fn.results_bbc_ucn(ploidy, clone_n))
             ll, nobs, n_clusters, n_samples = _compute_loglik_from_ucn(
                 ucn_file, clone_n, gammas, segs
             )

--- a/src/hatchet/compute_cn/solve/inference.py
+++ b/src/hatchet/compute_cn/solve/inference.py
@@ -374,7 +374,6 @@ def run_coordinate_descent(
     reg_bound=0.3,
     u_init_method="dirichlet",
     u_dir_alpha=0.3,
-    u_bin_p=0.5,
     solver_threads=None,
     cd_tol=0.001,
     solver_type="gurobi",
@@ -396,9 +395,7 @@ def run_coordinate_descent(
     """
     with Random(random_seed):
         seeds = [
-            build_random_u(
-                params, inputs, method=u_init_method, alpha=u_dir_alpha, p_bin=u_bin_p
-            )
+            build_random_u(params, inputs, method=u_init_method, alpha=u_dir_alpha)
             for _ in range(n_seed)
         ]
 

--- a/src/hatchet/compute_cn/solve/model.py
+++ b/src/hatchet/compute_cn/solve/model.py
@@ -133,41 +133,11 @@ def _random_tumor_props_bubble(n_tumor, minprop, size_bubbles=100):
     return t
 
 
-def _random_tumor_matrix_bin_dir(n_tumor, k, p_bin, alpha, minprop):
-    """Tumor proportion matrix (n_tumor, k) via anchored-Bernoulli + per-column Dirichlet.
-
-    1. Each clone is anchored to a uniformly-random sample (guarantees row >= 1).
-    2. For non-anchor cells, Bernoulli(p_bin).
-    3. Any all-zero column is fixed up by activating a random clone.
-    4. Per-sample Dirichlet(alpha) over active cells; inactive cells stay 0.
-    5. Same minprop floor + renorm as the other methods.
-    """
-    Z = (np.random.rand(n_tumor, k) < p_bin).astype(int)
-    anchors = np.random.randint(k, size=n_tumor)
-    Z[np.arange(n_tumor), anchors] = 1
-    for j in np.where(Z.sum(axis=0) == 0)[0]:
-        Z[np.random.randint(n_tumor), j] = 1
-
-    props = np.zeros((n_tumor, k))
-    for j in range(k):
-        active = np.where(Z[:, j] == 1)[0]
-        t = np.random.dirichlet([alpha] * len(active))
-        t[t < minprop] = 0
-        if t.sum() > 0:
-            t = t / t.sum()
-        else:
-            t = np.zeros(len(active))
-            t[np.random.randint(len(active))] = 1.0
-        props[active, j] = t
-    return props
-
-
 def build_random_u(
     params: SolverParams,
     inputs: SolverInputs,
     method="dirichlet",
     alpha=0.3,
-    p_bin=0.5,
     max_attempts=3,
 ):
     """Generate random U initialization matrix (n * k).
@@ -175,28 +145,13 @@ def build_random_u(
     Re-samples up to ``max_attempts`` times if any tumor clone (row 1..n-1)
     has zero proportion in every sample — such "wasted clone" seeds reduce
     an n-clone restart to an effective (n-1)-clone restart and are dropped
-    by the U-step's min_prop binary anyway. ``bin_dir`` guarantees row >= 1
-    by construction (anchored Bernoulli), so the retry rarely triggers there.
+    by the U-step's min_prop binary anyway.
     """
     U = np.empty((params.n, inputs.k))
     n_tumor = params.n - 1
 
     for _ in range(max_attempts):
-        if method == "bin_dir":
-            tumor_props = _random_tumor_matrix_bin_dir(
-                n_tumor, inputs.k, p_bin, alpha, params.minprop
-            )
-            for _k in range(inputs.k):
-                sid = inputs.sample_ids[_k]
-                if inputs.purities is not None and sid in inputs.purities:
-                    purity = inputs.purities[sid]
-                    U[0, _k] = 1 - purity
-                    U[1:, _k] = purity * tumor_props[:, _k]
-                else:
-                    U[:, _k] = _random_tumor_props_dirichlet(
-                        params.n, alpha, params.minprop
-                    )
-        elif method == "bubble":
+        if method == "bubble":
             for _k in range(inputs.k):
                 sid = inputs.sample_ids[_k]
                 if inputs.purities is not None and sid in inputs.purities:

--- a/src/hatchet/evaluate/evaluate.py
+++ b/src/hatchet/evaluate/evaluate.py
@@ -9,6 +9,7 @@ from hatchet.utils import (
     setup_logging,
 )
 from hatchet.io_utils import read_seg_ucn_file
+from hatchet import filenames as fn
 from hatchet.evaluate.evaluate_utils import (
     read_snv_vcf,
     read_snv_tsv,
@@ -55,7 +56,7 @@ def run(args=None):
     if eval_all and result_dir is not None:
         logging.info("evaluating all pool solutions")
         pool_eval = evaluate_pool_solutions(result_dir, snv_df, gamma=gamma)
-        out_path = os.path.join(out_dir, "pool_eval.tsv")
+        out_path = os.path.join(out_dir, fn.POOL_EVAL_TSV)
         pool_eval.to_csv(out_path, sep="\t", index=False)
         logging.info(f"wrote {out_path} ({len(pool_eval)} solutions)")
         return
@@ -65,7 +66,7 @@ def run(args=None):
     if seg_file is None:
         if result_dir is None:
             raise ValueError("Either --seg or --result_dir must be provided")
-        seg_file = os.path.join(result_dir, "best.seg.ucn")
+        seg_file = os.path.join(result_dir, fn.BEST_SEG_UCN)
     segs, clones = read_seg_ucn_file(seg_file)
     clone_props = segs[[f"u_{c}" for c in clones]].iloc[0].tolist()
 
@@ -112,7 +113,7 @@ def run(args=None):
 
     if all_results:
         all_df = pd.concat(all_results, ignore_index=True)
-        out_snv = os.path.join(out_dir, "somatic_snvs.tsv")
+        out_snv = os.path.join(out_dir, fn.SOMATIC_SNVS_TSV)
         all_df.to_csv(out_snv, sep="\t", index=False)
         logging.info(f"wrote {out_snv} ({len(all_df)} SNVs)")
 
@@ -150,11 +151,11 @@ def run(args=None):
                     states = [(int(a), int(b)) for a, b in a_b]
                     _, _, _, exp_baf = compute_expected_baf_fcn(states, clone_props)
                     segs_plot.at[idx, "predicted_VAF"] = exp_baf
-                out_plot = os.path.join(out_dir, f"{sample}.vaf_1d.pdf")
+                out_plot = os.path.join(out_dir, fn.vaf_1d_pdf(sample))
                 plot_vaf_1d(sample_df, segs_plot, genome_axis, out_plot)
 
     if summary_rows:
         summary_df = pd.DataFrame(summary_rows)
-        out_summary = os.path.join(out_dir, "eval_summary.tsv")
+        out_summary = os.path.join(out_dir, fn.EVAL_SUMMARY_TSV)
         summary_df.to_csv(out_summary, sep="\t", index=False)
         logging.info(f"wrote {out_summary}")

--- a/src/hatchet/evaluate/evaluate_utils.py
+++ b/src/hatchet/evaluate/evaluate_utils.py
@@ -6,6 +6,7 @@ import numpy as np
 import pandas as pd
 
 from hatchet.evaluate.vaf_utils import estimate_vaf, is_explained_mut, relative_error
+from hatchet import filenames as fn
 
 
 def read_snv_vcf(vcf_path, sample="tumor"):
@@ -367,9 +368,9 @@ def evaluate_pool_solutions(result_dir, snv_df, gamma=0.05):
     Returns a DataFrame with one row per pool solution: ploidy, n_clones, tag,
     IMF/REG objectives (from summary.tsv), and VAF evaluation metrics.
     """
-    summary_path = os.path.join(result_dir, "summary.tsv")
-    bbc_path = os.path.join(result_dir, "bulk.good.bbc")
-    sols_dir = os.path.join(result_dir, "sols")
+    summary_path = os.path.join(result_dir, fn.SUMMARY_TSV)
+    bbc_path = os.path.join(result_dir, "bulk.good.bbc")  # legacy: no current producer
+    sols_dir = os.path.join(result_dir, fn.SOLS_DIR)
 
     summary = pd.read_csv(summary_path, sep="\t")
     bbc_df = pd.read_csv(bbc_path, sep="\t")
@@ -386,8 +387,10 @@ def evaluate_pool_solutions(result_dir, snv_df, gamma=0.05):
         if not m:
             continue
         pparam, pidx = m.group(1), m.group(2)
-        sol_subdir = os.path.join(sols_dir, f"{ploidy}_n{n_clones}")
-        sol_file = os.path.join(sol_subdir, f"cd_sol{pparam}_pool{pidx}.tsv")
+        sol_subdir = os.path.join(sols_dir, fn.ploidy_n_subdir(ploidy, n_clones))
+        sol_file = os.path.join(
+            sol_subdir, f"cd_sol{pparam}_pool{pidx}.tsv"
+        )  # legacy format
         if not os.path.exists(sol_file):
             logging.warning(f"sol file not found: {sol_file}")
             continue

--- a/src/hatchet/filenames.py
+++ b/src/hatchet/filenames.py
@@ -1,0 +1,164 @@
+"""HATCHet input/output constant filenames and subdirectories.
+
+Producers and consumers of a file must import the SAME name from here, so a
+rename cannot silently break a cross-stage contract. Fixed names are module
+constants; names that embed run parameters (ploidy, clone count, K, sample) are
+helper functions.
+
+Notes:
+    Purely user-named outputs (e.g. plot out_prefix) are not centralized here.
+    The legacy ``evaluate_pool_solutions`` reader references filenames with no
+    current producer and is intentionally not represented here.
+"""
+
+# =============================================================================
+# Subdirectories
+# =============================================================================
+LABELS_DIR = "labels"  # cluster-bins per-K BBC/SEG
+PLOTS_DIR = "plots"  # cluster-bins + compute-cn plots
+TRACES_DIR = "traces"  # cluster-bins EM traces
+INIT_DIAG_DIR = "init_diag"  # cluster-bins init diagnostics
+SOLS_DIR = "sols"  # compute-cn per-(ploidy, n) solutions
+
+
+# =============================================================================
+# cluster-bins inputs (bb_dir)
+# =============================================================================
+BB_TSV_GZ = "bb.tsv.gz"
+SAMPLE_IDS = "sample_ids.tsv"
+BB_RDR_NPZ = "bb.rdr.npz"
+BB_DEPTH_NPZ = "bb.depth.npz"
+BB_A_ALLELE_NPZ = "bb.Aallele.npz"
+BB_B_ALLELE_NPZ = "bb.Ballele.npz"
+BB_T_ALLELE_NPZ = "bb.Tallele.npz"
+
+
+# =============================================================================
+# cluster-bins outputs (bbc_dir)
+# =============================================================================
+BULK_BBC = "bulk.bbc"
+BULK_SEG = "bulk.seg"
+BB_PHASED_TSV_GZ = "bb.phased.tsv.gz"
+MODEL_SCORES_TSV = "model_scores.tsv"
+MODEL_SCORES_PDF = "model_scores.pdf"
+ELBO_TRACES_PDF = "elbo_traces.pdf"
+HMM_INIT_PDF = "hmm_init.pdf"
+
+
+def bulk_k_bbc(k) -> str:
+    """Per-K clustered BBC under labels/."""
+    return f"bulk{k}.bbc"
+
+
+def bulk_k_seg(k) -> str:
+    """Per-K segment SEG under labels/."""
+    return f"bulk{k}.seg"
+
+
+def bulk_k_phased(k) -> str:
+    """Per-K phased bins under labels/."""
+    return f"bulk{k}.bb.phased.tsv.gz"
+
+
+def k_em_trace(k) -> str:
+    """Per-K EM parameter trace under traces/."""
+    return f"K{k}.em_trace.npz"
+
+
+def k_plot(k) -> str:
+    """Per-K 1D/2D plot under plots/."""
+    return f"K{k}.pdf"
+
+
+def bulk_k_plot(k) -> str:
+    """Best-K plot copied to the top-level bbc_dir."""
+    return f"bulk.K{k}.pdf"
+
+
+def init_pdf(name) -> str:
+    """Per-init-method HMM init diagnostic under init_diag/."""
+    return f"{name}_init.pdf"
+
+
+# =============================================================================
+# compute-cn outputs (result_dir)
+# =============================================================================
+GAMMAS = "gammas.tsv"
+SCALING_2D_PDF = "scaling_2d.pdf"
+SUMMARY_TSV = "summary.tsv"
+BEST_BBC_UCN = "best.bbc.ucn"
+BEST_SEG_UCN = "best.seg.ucn"
+MODEL_SELECTION_PDF = "model_selection.pdf"
+POOL_PDF = "pool.pdf"
+# sols/
+OBJECTIVES_TSV = "objectives.tsv"
+U0_SEEDS_TSV = "u0_seeds.tsv"
+
+
+def solver_input(ploidy) -> str:
+    """Per-ploidy solver input under sols/."""
+    return f"solver_input.{ploidy}.tsv"
+
+
+def results_bbc_ucn(ploidy, n) -> str:
+    """Per-(ploidy, n) bin-level UCN."""
+    return f"results.{ploidy}.n{n}.bbc.ucn.tsv"
+
+
+def results_seg_ucn(ploidy, n) -> str:
+    """Per-(ploidy, n) segment-level UCN."""
+    return f"results.{ploidy}.n{n}.seg.ucn.tsv"
+
+
+def chosen_bbc_ucn(ploidy) -> str:
+    """Model-selected bin-level UCN for one ploidy."""
+    return f"chosen.{ploidy}.bbc.ucn"
+
+
+def chosen_seg_ucn(ploidy) -> str:
+    """Model-selected segment-level UCN for one ploidy."""
+    return f"chosen.{ploidy}.seg.ucn"
+
+
+def ploidy_n_subdir(ploidy, n) -> str:
+    """Per-(ploidy, n) leaf directory name (under sols/ and plots/)."""
+    return f"{ploidy}_n{n}"
+
+
+def solution_stem(solve_mode, sol_id) -> str:
+    """Per-solution filename stem (extension appended by the caller: .tsv/.nwk/.json)."""
+    return f"{solve_mode}_{sol_id}"
+
+
+def solution_tsv(solve_mode, sol_id) -> str:
+    """Per-solution detail TSV under a sols/<ploidy>_n<n>/ directory."""
+    return solution_stem(solve_mode, sol_id) + ".tsv"
+
+
+def pool_pdf(pid, ploidy, n) -> str:
+    """Pool CNP panel for one (ploidy, n)."""
+    return f"{pid}.pool_{ploidy}_n{n}.pdf"
+
+
+# =============================================================================
+# evaluate outputs (out_dir)
+# =============================================================================
+SOMATIC_SNVS_TSV = "somatic_snvs.tsv"
+POOL_EVAL_TSV = "pool_eval.tsv"
+EVAL_SUMMARY_TSV = "eval_summary.tsv"
+
+
+def vaf_1d_pdf(sample) -> str:
+    """Per-sample VAF 1D plot."""
+    return f"{sample}.vaf_1d.pdf"
+
+
+# =============================================================================
+# logs
+# =============================================================================
+RUNTIME_LOG = "runtime.log"
+
+
+def command_log(command) -> str:
+    """Per-command file log written into the command's output directory."""
+    return f"{command}.log"

--- a/src/hatchet/hatchet.yaml
+++ b/src/hatchet/hatchet.yaml
@@ -89,34 +89,52 @@ solver_threads: null
 eps_fit: 0.01
 
 ##################################################
-# plot-cn / plot-panel (shared --dpi default)
-dpi: 300
-# img_type: pdf | png | svg
-img_type: png
-transparent: false
-show_gap: false
-tail_alpha: 0.8
-center_alpha: 1.0
-onetail_area: 0.025
-maxlim_fcn: 30
+# plotting (shared: cluster-bins plot-rdr-baf + plot-cn + plot-panel)
+plot_dpi: 300
+# plot_img_type: pdf | png | svg
+plot_img_type: png
+plot_transparent: false
+plot_show_gap: false
+
+# transparent outlier dots
+plot_tail_alpha: 0.8
+plot_center_alpha: 1.0
+plot_onetail_area: 0.025
+plot_maxlim_fcn: 30
 patient_id: panel
 # combined 1D figure width (inches)
 plot_row_width: 25
 # per-sample vertical block height (inches)
-plot_row_height: 6
-# vertical gap between samples (GridSpec hspace)
-plot_inter_sample_hspace: 0.35
-# vertical gap between FCN and BAF within a sample
-plot_intra_sample_hspace: 0.12
-# vertical gap between last BAF row and CNP profile
-plot_baf_cnp_hspace: 0.3
+plot_row_height: 4
+# vertical gap between samples; fraction of a full (n_rows-tall) sample block
+plot_inter_sample_hspace: 0.15
+# vertical gap between the two rows within a sample; fraction of one row
+plot_intra_sample_hspace: 0.05
+# vertical gap between last BAF row and CNP profile (plot-cn only)
+plot_baf_cnp_hspace: 0.15
+# dot marker size
+plot_markersize: 5
+# legend marker size
+plot_legend_markersize: 5
+plot_legend_fontsize: 8
+plot_maxlim_rdr: 100
+# cluster-bins per-cluster diagnostic pages (plot_clusters)
+plot_diag_col_width: 7
+plot_diag_page_height: 12
+plot_diag_hist_bins: 80
+plot_diag_scatter_size: 4
+plot_diag_scatter_alpha: 0.3
+plot_diag_contour_levels: 6
+plot_diag_suptitle_fontsize: 14
+plot_diag_title_fontsize: 10
+plot_diag_label_fontsize: 9
+plot_diag_legend_fontsize: 7
 
 ##################################################
 # plot-panel
-width: 20
-height: 1
+plot_panel_width: 20
+plot_panel_height: 1
 show_clone_name: false
-show_prop: false
 show_ploidy: false
 title: panel
 plot_1d2d: false

--- a/src/hatchet/hatchet.yaml
+++ b/src/hatchet/hatchet.yaml
@@ -1,4 +1,4 @@
-# HATCHet3 default parameter values for all subcommands.
+# HATCHet default parameter values for all subcommands.
 # Loaded by hatchet.utils.normalize_args at the top of each run().
 
 ##################################################

--- a/src/hatchet/hatchet.yaml
+++ b/src/hatchet/hatchet.yaml
@@ -45,7 +45,7 @@ skip_mhbafs: false
 
 ##################################################
 # compute-cn
-# mode: ilp | cd | both | cnt_cd
+# mode: ilp | cd | both
 mode: cd
 # model_select: elbow | bic
 model_select: bic
@@ -80,11 +80,9 @@ cd_convergence_iters: 2
 cd_nseeds: 400
 cd_njobs: 8
 cd_seed: 42
-# u_init: dirichlet | bubble | bin_dir
+# u_init: dirichlet | bubble
 u_init: dirichlet
 u_dir_alpha: 0.3
-# bin_dir only: Bernoulli presence prob for non-anchor cells
-u_bin_p: 0.5
 solver_threads: null
 eps_fit: 0.01
 

--- a/src/hatchet/hatchet_parser.py
+++ b/src/hatchet/hatchet_parser.py
@@ -285,6 +285,7 @@ def add_arguments_cluster_bins(parser: argparse.ArgumentParser):
         help="Skip mhBAF folding after decoding. By default, clusters with BAF > 0.5 "
         "have their BAF means and per-bin phases flipped to enforce the minor-allele convention.",
     )
+    add_arguments_plot_style(parser)
     return parser
 
 
@@ -681,6 +682,77 @@ def parse_arguments_compute_cn(args):
 
 
 ##################################################
+def add_arguments_plot_style(parser: argparse.ArgumentParser):
+    """Register every ``plot_*`` styling knob as a hidden CLI override.
+
+    All flags use ``default=argparse.SUPPRESS`` (so the hatchet.yaml value is the effective
+    default) and ``help=argparse.SUPPRESS`` (so they stay out of ``-h``). Shared by every plot
+    subcommand (cluster-bins, plot-cn, plot-panel); each reads only the keys it needs, so a key
+    unused by one command is simply an inert override there.
+    """
+    float_keys = [
+        "plot_row_width",
+        "plot_row_height",
+        "plot_inter_sample_hspace",
+        "plot_intra_sample_hspace",
+        "plot_baf_cnp_hspace",
+        "plot_markersize",
+        "plot_legend_markersize",
+        "plot_tail_alpha",
+        "plot_center_alpha",
+        "plot_onetail_area",
+        "plot_diag_col_width",
+        "plot_diag_page_height",
+        "plot_diag_scatter_size",
+        "plot_diag_scatter_alpha",
+    ]
+    int_keys = [
+        "plot_dpi",
+        "plot_maxlim_fcn",
+        "plot_maxlim_rdr",
+        "plot_legend_fontsize",
+        "plot_diag_hist_bins",
+        "plot_diag_contour_levels",
+        "plot_diag_suptitle_fontsize",
+        "plot_diag_title_fontsize",
+        "plot_diag_label_fontsize",
+        "plot_diag_legend_fontsize",
+    ]
+    bool_keys = ["plot_transparent", "plot_show_gap"]
+    for key in float_keys:
+        parser.add_argument(
+            f"--{key}",
+            type=float,
+            required=False,
+            default=argparse.SUPPRESS,
+            help=argparse.SUPPRESS,
+        )
+    for key in int_keys:
+        parser.add_argument(
+            f"--{key}",
+            type=int,
+            required=False,
+            default=argparse.SUPPRESS,
+            help=argparse.SUPPRESS,
+        )
+    for key in bool_keys:
+        parser.add_argument(
+            f"--{key}",
+            action="store_true",
+            default=argparse.SUPPRESS,
+            help=argparse.SUPPRESS,
+        )
+    parser.add_argument(
+        "--plot_img_type",
+        type=str,
+        choices=["pdf", "png", "svg"],
+        default=argparse.SUPPRESS,
+        help=argparse.SUPPRESS,
+    )
+    return parser
+
+
+##################################################
 def add_arguments_plot_cn(parser: argparse.ArgumentParser):
     parser.add_argument(
         "--bbc",
@@ -729,63 +801,6 @@ def add_arguments_plot_cn(parser: argparse.ArgumentParser):
         help="Directory for output files",
     )
     parser.add_argument(
-        "--dpi",
-        required=False,
-        type=int,
-        help="image resolution (default: 500)",
-        default=argparse.SUPPRESS,
-    )
-    parser.add_argument(
-        "--img_type",
-        required=False,
-        choices=["pdf", "png", "svg"],
-        type=str,
-        help="file format (default: png)",
-        default=argparse.SUPPRESS,
-    )
-    parser.add_argument(
-        "--transparent",
-        required=False,
-        action="store_true",
-        default=argparse.SUPPRESS,
-        help="transparent background (default: False)",
-    )
-    parser.add_argument(
-        "--show_gap",
-        required=False,
-        action=argparse.BooleanOptionalAction,
-        default=argparse.SUPPRESS,
-        help="show gap regions (uncollapsed) in the plot (default: False)",
-    )
-    parser.add_argument(
-        "--tail_alpha",
-        required=False,
-        type=float,
-        help="transparency on the tail region per CN state (default: 0.8)",
-        default=argparse.SUPPRESS,
-    )
-    parser.add_argument(
-        "--center_alpha",
-        required=False,
-        type=float,
-        help="transparency on the center region per CN state (default: 1.0)",
-        default=argparse.SUPPRESS,
-    )
-    parser.add_argument(
-        "--onetail_area",
-        required=False,
-        type=float,
-        help="area for each tail per CN state to set transparency (default: 0.025)",
-        default=argparse.SUPPRESS,
-    )
-    parser.add_argument(
-        "--maxlim_fcn",
-        required=False,
-        type=int,
-        help="figure axis limit for FCN (default: 30)",
-        default=argparse.SUPPRESS,
-    )
-    parser.add_argument(
         "--ploidy",
         required=True,
         choices=["diploid", "tetraploid"],
@@ -798,6 +813,7 @@ def add_arguments_plot_cn(parser: argparse.ArgumentParser):
         type=str,
         help="Output filename prefix for combined plots (e.g. 'LuCaP173')",
     )
+    add_arguments_plot_style(parser)
     return parser
 
 
@@ -822,14 +838,14 @@ def add_arguments_plot_panel(parser: argparse.ArgumentParser):
         help="Reference chromosome BED file (e.g., hg19.chrom.bed)",
     )
     parser.add_argument(
-        "--width",
+        "--plot_panel_width",
         required=False,
         type=int,
         help="panel image width (default: 20)",
         default=argparse.SUPPRESS,
     )
     parser.add_argument(
-        "--height",
+        "--plot_panel_height",
         required=False,
         type=int,
         help="panel image height per row (default: 1)",
@@ -841,13 +857,6 @@ def add_arguments_plot_panel(parser: argparse.ArgumentParser):
         action=argparse.BooleanOptionalAction,
         default=argparse.SUPPRESS,
         help="plot clone name (default: False)",
-    )
-    parser.add_argument(
-        "--show_prop",
-        required=False,
-        action=argparse.BooleanOptionalAction,
-        default=argparse.SUPPRESS,
-        help="plot clone proportion (default: False)",
     )
     parser.add_argument(
         "--show_ploidy",
@@ -862,20 +871,6 @@ def add_arguments_plot_panel(parser: argparse.ArgumentParser):
         default=argparse.SUPPRESS,
         type=float,
         help="hide tumor clones below this proportion from the panel (default: 0.01)",
-    )
-    parser.add_argument(
-        "--dpi",
-        required=False,
-        type=int,
-        help="image resolution (default: 300)",
-        default=argparse.SUPPRESS,
-    )
-    parser.add_argument(
-        "--transparent",
-        required=False,
-        action="store_true",
-        default=argparse.SUPPRESS,
-        help="transparent background (default: False)",
     )
     parser.add_argument(
         "--title",
@@ -906,6 +901,7 @@ def add_arguments_plot_panel(parser: argparse.ArgumentParser):
         help="emit per-sample tumor purity + ploidy barplots; one page per "
         "metric per cancer_type (or single page per metric if column absent)",
     )
+    add_arguments_plot_style(parser)
     return parser
 
 

--- a/src/hatchet/hatchet_parser.py
+++ b/src/hatchet/hatchet_parser.py
@@ -314,7 +314,7 @@ def add_arguments_compute_cn(parser: argparse.ArgumentParser):
     parser.add_argument(
         "--mode",
         required=False,
-        choices=["both", "cd", "ilp", "cnt_cd"],
+        choices=["both", "cd", "ilp"],
         type=str,
         help="Solver mode (default: cd)",
         default=argparse.SUPPRESS,
@@ -565,10 +565,10 @@ def add_arguments_compute_cn(parser: argparse.ArgumentParser):
     parser.add_argument(
         "--u_init",
         required=False,
-        choices=["dirichlet", "bubble", "bin_dir"],
+        choices=["dirichlet", "bubble"],
         default=argparse.SUPPRESS,
         type=str,
-        help="U initialization method: dirichlet | bubble | bin_dir",
+        help="U initialization method: dirichlet | bubble",
     )
 
     parser.add_argument(
@@ -580,14 +580,6 @@ def add_arguments_compute_cn(parser: argparse.ArgumentParser):
     )
 
     parser.add_argument(
-        "--u_bin_p",
-        required=False,
-        default=argparse.SUPPRESS,
-        type=float,
-        help="bin_dir: per-cell Bernoulli presence probability (anchor sample always 1)",
-    )
-
-    parser.add_argument(
         "--solver_threads",
         required=False,
         default=argparse.SUPPRESS,
@@ -596,20 +588,20 @@ def add_arguments_compute_cn(parser: argparse.ArgumentParser):
     )
 
     ##################################################
-    # CNT-CD parameters
+    # CNT-CD parameters (Experimental)
     parser.add_argument(
         "--tree_file",
         required=False,
         default=None,
         type=str,
-        help="CNT-CD: Newick tree file. If not provided, enumerate all unlabeled shapes.",
+        help=argparse.SUPPRESS,
     )
     parser.add_argument(
         "--eps_fit",
         required=False,
         default=argparse.SUPPRESS,
         type=float,
-        help="CNT-CD: fit tolerance for C-step CNT stage lexicographic bound (default: 0.01)",
+        help=argparse.SUPPRESS,  # cnt_cd only; not user-selectable pre-release
     )
 
     parser.add_argument(

--- a/src/hatchet/plot/plot_cluster_bins.py
+++ b/src/hatchet/plot/plot_cluster_bins.py
@@ -11,12 +11,18 @@ from scipy.stats import norm, beta as beta_dist, gaussian_kde
 from scipy.signal import find_peaks
 
 from cnplot import (
-    plot_scatter_1d,
+    plot_scatter_1d_multisample,
     plot_scatter_2d,
+    make_row_spec,
     annotate_landmarks,
     set_palette,
 )
-from hatchet.plot.plot_utils import build_genome_axis, use_editable_fonts
+from hatchet.plot.plot_utils import (
+    get_plot_style,
+    build_genome_axis,
+    use_editable_fonts,
+)
+from hatchet.utils import load_defaults
 
 
 ##################################################
@@ -51,6 +57,7 @@ def plot_clusters(
     bin_info=None,
     lim_baf: tuple = None,
     lim_rdr: tuple = None,
+    style: dict = None,
 ):
     """Plot per-cluster joint BAF-vs-RDR scatter with marginals and QQ plots.
 
@@ -72,6 +79,18 @@ def plot_clusters(
     """
     import warnings
     from matplotlib.gridspec import GridSpec, GridSpecFromSubplotSpec
+
+    style = style or get_plot_style(load_defaults())
+    col_width = style["diag_col_width"]
+    page_height = style["diag_page_height"]
+    hist_bins = style["diag_hist_bins"]
+    scatter_size = style["diag_scatter_size"]
+    scatter_alpha = style["diag_scatter_alpha"]
+    contour_levels = style["diag_contour_levels"]
+    suptitle_fs = style["diag_suptitle_fontsize"]
+    title_fs = style["diag_title_fontsize"]
+    label_fs = style["diag_label_fontsize"]
+    legend_fs = style["diag_legend_fontsize"]
 
     K = rdr_means.shape[0]
     M = rdr_means.shape[1]
@@ -106,8 +125,8 @@ def plot_clusters(
             title = f"Cluster {k}  (n={n_bins}/{N_total})"
             title_color = "red" if is_multimodal else "black"
 
-            fig = plt.figure(figsize=(7 * M, 12))
-            fig.suptitle(title, fontsize=14, y=0.99, color=title_color)
+            fig = plt.figure(figsize=(col_width * M, page_height))
+            fig.suptitle(title, fontsize=suptitle_fs, y=0.99, color=title_color)
             outer = GridSpec(
                 2, M, figure=fig, height_ratios=[3, 2], wspace=0.35, hspace=0.35
             )
@@ -149,8 +168,8 @@ def plot_clusters(
                 ax_main.scatter(
                     baf_obs,
                     rdr_obs,
-                    s=4,
-                    alpha=0.3,
+                    s=scatter_size,
+                    alpha=scatter_alpha,
                     color=cluster_color,
                     rasterized=True,
                 )
@@ -165,20 +184,20 @@ def plot_clusters(
                         Xg,
                         Yg,
                         np.exp(log_joint),
-                        levels=6,
+                        levels=contour_levels,
                         colors="red",
                         linewidths=0.8,
                         alpha=0.7,
                     )
-                ax_main.set_xlabel("BAF", fontsize=9)
-                ax_main.set_ylabel(ylab, fontsize=9)
+                ax_main.set_xlabel("BAF", fontsize=label_fs)
+                ax_main.set_ylabel(ylab, fontsize=label_fs)
                 if lim_baf is not None:
                     ax_main.set_xlim(lim_baf)
                 if lim_rdr is not None:
                     ax_main.set_ylim(lim_rdr)
 
                 ax_top.hist(
-                    baf_obs, bins=80, density=True, alpha=0.6, color="steelblue"
+                    baf_obs, bins=hist_bins, density=True, alpha=0.6, color="steelblue"
                 )
                 if a_param > 0 and b_param > 0:
                     x_baf = np.linspace(0.001, 0.999, 300)
@@ -189,13 +208,13 @@ def plot_clusters(
                         lw=1.2,
                         label=f"p={p_k:.3f} tau={tau_m:.0f}",
                     )
-                    ax_top.legend(fontsize=7, loc="upper right")
+                    ax_top.legend(fontsize=legend_fs, loc="upper right")
                 ax_top.tick_params(labelbottom=False)
-                ax_top.set_title(tumor_samples[m], fontsize=10)
+                ax_top.set_title(tumor_samples[m], fontsize=title_fs)
 
                 ax_right.hist(
                     rdr_obs,
-                    bins=80,
+                    bins=hist_bins,
                     density=True,
                     alpha=0.6,
                     color="salmon",
@@ -209,7 +228,7 @@ def plot_clusters(
                     lw=1.2,
                     label=f"mu={mu_k:.3f}\nvar={var_k:.4f}",
                 )
-                ax_right.legend(fontsize=7, loc="upper right")
+                ax_right.legend(fontsize=legend_fs, loc="upper right")
                 ax_right.tick_params(labelleft=False)
 
                 inner_qq = GridSpecFromSubplotSpec(
@@ -239,13 +258,13 @@ def plot_clusters(
                         0.95,
                         f"$R^2$={r2_baf:.4f}",
                         transform=ax_baf_qq.transAxes,
-                        fontsize=9,
+                        fontsize=label_fs,
                         va="top",
                         ha="left",
                     )
-                ax_baf_qq.set_xlabel("Theoretical (Beta)", fontsize=9)
-                ax_baf_qq.set_ylabel("Observed", fontsize=9)
-                ax_baf_qq.set_title("BAF QQ", fontsize=10)
+                ax_baf_qq.set_xlabel("Theoretical (Beta)", fontsize=label_fs)
+                ax_baf_qq.set_ylabel("Observed", fontsize=label_fs)
+                ax_baf_qq.set_title("BAF QQ", fontsize=title_fs)
 
                 ax_rdr_qq = fig.add_subplot(inner_qq[0, 1])
                 rdr_sorted = np.sort(rdr_obs)
@@ -262,13 +281,13 @@ def plot_clusters(
                     0.95,
                     f"$R^2$={r2_rdr:.4f}",
                     transform=ax_rdr_qq.transAxes,
-                    fontsize=9,
+                    fontsize=label_fs,
                     va="top",
                     ha="left",
                 )
-                ax_rdr_qq.set_xlabel("Theoretical (Gaussian)", fontsize=9)
-                ax_rdr_qq.set_ylabel("Observed", fontsize=9)
-                ax_rdr_qq.set_title(f"{ylab} QQ", fontsize=10)
+                ax_rdr_qq.set_xlabel("Theoretical (Gaussian)", fontsize=label_fs)
+                ax_rdr_qq.set_ylabel("Observed", fontsize=label_fs)
+                ax_rdr_qq.set_title(f"{ylab} QQ", fontsize=title_fs)
 
             fig.subplots_adjust(top=0.95)
             pdf.savefig(fig)
@@ -296,11 +315,7 @@ def plot_rdr_baf(
     ylab="RDR",
     out_dir=None,
     out_prefix="",
-    dpi=300,
-    transparent=False,
-    row_width=20,
-    row_height=4,
-    maxlim_rdr=100,
+    style: dict = None,
     rasterized=True,
     rdr_means=None,
     rdr_vars=None,
@@ -321,6 +336,7 @@ def plot_rdr_baf(
         genome_file: Chromosome-sizes file path for the genome axis.
         region_bed: Plotted-regions BED path for the genome axis.
     """
+    style = style or get_plot_style(load_defaults())
     use_editable_fonts()
 
     bin_info = bin_info.copy(deep=True)
@@ -335,7 +351,10 @@ def plot_rdr_baf(
     pal_dict = None  # {str(cluster): color} for cnplot hue
     lbl_to_idx = None
     if cluster_labels is not None:
-        palette = set_palette(num_colors=len(np.unique(cluster_labels)))
+        # rc_context reverts set_palette's global whitegrid style leak
+        # (axes.edgecolor -> gray) so 1D/2D panels keep a black axes box.
+        with plt.rc_context():
+            palette = set_palette(num_colors=len(np.unique(cluster_labels)))
         lbl_to_idx = np.empty(int(cluster_labels.max()) + 1, dtype=int)
         for i, lbl in enumerate(unique_labels):
             lbl_to_idx[lbl] = i
@@ -350,9 +369,16 @@ def plot_rdr_baf(
     pdf = PdfPages(os.path.join(out_dir, f"{out_name}.pdf"))
 
     global_lim_baf = (0, 1) if np.max(baf_mat) > 0.5 else (0, 0.55)
+    global_lim_baf_1d = (global_lim_baf[0] - 0.05, global_lim_baf[1] + 0.05)
     global_max_rdr = int(np.ceil(np.max(rdr_mat)))
-    global_lim_rdr = (0, min(max(2, global_max_rdr), maxlim_rdr))
+    top_rdr = min(max(2, global_max_rdr), style["maxlim_rdr"])
+    global_lim_rdr = (-0.05 * top_rdr, top_rdr)
 
+    hue = "cluster" if cluster_labels is not None else None
+    xlab_2d = "Minor haplotype B-allele frequency (mhBAF)" if xlab == "mhBAF" else xlab
+    obs_parts = []
+    exp_parts = []
+    titles = {}
     for si, sample in enumerate(samples):
         logging.info(f"plot {sample}")
         bafs = baf_mat[:, si]
@@ -360,26 +386,27 @@ def plot_rdr_baf(
 
         lim_baf = (0, 1) if np.max(bafs) > 0.5 else (0, 0.55)
         max_rdr = int(np.ceil(np.max(rdrs)))
-        if max_rdr > maxlim_rdr:
-            num_exceeded = np.sum(rdrs >= maxlim_rdr)
+        if max_rdr > style["maxlim_rdr"]:
+            num_exceeded = np.sum(rdrs >= style["maxlim_rdr"])
             logging.warning(
-                f"there are {num_exceeded} bins having RDR exceed maxlim_rdr={maxlim_rdr}"
+                f"there are {num_exceeded} bins having RDR exceed maxlim_rdr={style['maxlim_rdr']}"
             )
-        lim_rdr = (0, min(max(2, max_rdr), maxlim_rdr))
+        lim_rdr = (0, min(max(2, max_rdr), style["maxlim_rdr"]))
 
         obs = bin_info[["#CHR", "START", "END"]].copy()
         obs["BAF"] = bafs
         obs["RD"] = rdrs
-        exp = None
-        hue = None
+        obs["SAMPLE"] = sample
         if cluster_labels is not None:
             obs["cluster"] = [str(c) for c in cluster_labels]
-            hue = "cluster"
             exp = bin_info[["#CHR", "START", "END"]].copy()
             exp[f"exp_RD_{sample}"] = expected_rdrs[lbl_to_idx[cluster_labels], si]
             exp[f"exp_BAF_{sample}"] = expected_bafs[lbl_to_idx[cluster_labels], si]
+            exp_parts.append(exp)
+        obs_parts.append(obs)
+        titles[sample] = sample
 
-        # Page 1: 2D plot
+        # 2D page (one per sample)
         grid = plot_scatter_2d(
             obs,
             xcol="BAF",
@@ -389,11 +416,12 @@ def plot_rdr_baf(
             palette=pal_dict,
             xlim=lim_baf,
             ylim=lim_rdr,
-            xlabel=xlab,
+            xlabel=xlab_2d,
             ylabel=ylab,
-            title=f"sample={sample}",
+            title=sample,
             show_marginals=True,
             show_props=False,
+            markersize=style["markersize"],
             rasterized=rasterized,
         )
         if cluster_labels is not None:
@@ -410,71 +438,73 @@ def plot_rdr_baf(
             ]
             if landmarks:
                 annotate_landmarks(grid.ax_joint, landmarks)
-        pdf.savefig(grid.figure, dpi=dpi, bbox_inches="tight", transparent=transparent)
+        pdf.savefig(
+            grid.figure,
+            dpi=style["dpi"],
+            bbox_inches="tight",
+            transparent=style["transparent"],
+        )
         plt.close(grid.figure)
 
-        # Page 2: 1D plot
-        fig, axes = plt.subplots(nrows=2, ncols=1, figsize=(row_width, row_height))
-        plot_scatter_1d(
-            axes[0],
-            obs,
-            genome_axis,
-            "RD",
-            expected_df=exp,
-            group=sample,
-            hue=hue,
-            palette=pal_dict,
-            ylim=lim_rdr,
-            ylabel=ylab,
-            plot_chrname=False,
-            show_legend=False,
-            rasterized=rasterized,
-        )
-        plot_scatter_1d(
-            axes[1],
-            obs,
-            genome_axis,
-            "BAF",
-            expected_df=exp,
-            group=sample,
-            hue=hue,
-            palette=pal_dict,
-            ylim=lim_baf,
-            ylabel=xlab,
-            href=0.5,
-            plot_chrname=True,
-            rasterized=rasterized,
-        )
-        fig.suptitle(f"sample={sample}")
-        if cluster_labels is not None:
-            handles = [
-                Line2D(
-                    [0],
-                    [0],
-                    marker="o",
-                    linestyle="",
-                    markersize=5,
-                    color=pal_dict[str(lbl)],
-                    label=str(lbl),
-                )
-                for lbl in unique_labels
-            ]
-            ncol = max(1, int(np.ceil(len(unique_labels) / 10)))
-            axes[0].legend(
-                handles=handles,
-                loc="center left",
-                bbox_to_anchor=(1.01, 0.5),
-                frameon=False,
-                title=None,
-                ncol=ncol,
-                fontsize=8,
+    # Combined 1D page: all samples stacked, RDR + BAF rows per sample
+    obs_all = pd.concat(obs_parts, ignore_index=True)
+    exp_1d = None
+    if exp_parts:
+        exp_1d = exp_parts[0]
+        for part in exp_parts[1:]:
+            exp_1d = exp_1d.merge(part, on=["#CHR", "START", "END"], how="outer")
+    fig = plot_scatter_1d_multisample(
+        obs_df=obs_all,
+        genome_axis=genome_axis,
+        row_specs=[
+            make_row_spec("RD", ylabel=ylab, ylim=global_lim_rdr),
+            make_row_spec("BAF", ylabel=xlab, ylim=global_lim_baf_1d, href=0.5),
+        ],
+        groups=samples,
+        group_col="SAMPLE",
+        expected_df=exp_1d,
+        hue=hue,
+        palette=pal_dict,
+        seg_df=None,
+        titles=titles,
+        row_width=style["row_width"],
+        row_height=style["row_height"],
+        intra_group_hspace=style["intra_sample_hspace"],
+        inter_group_hspace=style["inter_sample_hspace"],
+        markersize=style["markersize"],
+        rasterized=rasterized,
+    )
+    if cluster_labels is not None:
+        handles = [
+            Line2D(
+                [0],
+                [0],
+                marker="o",
+                linestyle="",
+                markersize=style["legend_markersize"],
+                color=pal_dict[str(lbl)],
+                label=str(lbl),
             )
-        fig.subplots_adjust(right=0.82)
-        fig.tight_layout(rect=[0, 0, 0.82, 1])
-        pdf.savefig(fig, dpi=dpi, bbox_inches="tight")
-        plt.close(fig)
+            for lbl in unique_labels
+        ]
+        ncol = max(1, int(np.ceil(len(unique_labels) / 10)))
+        # anchor to the top panel's top-right corner so the legend sits snug
+        # beside the axes rather than floating at the figure's right edge
+        fig.axes[0].legend(
+            handles=handles,
+            loc="upper left",
+            bbox_to_anchor=(1.01, 1.0),
+            frameon=False,
+            title=None,
+            ncol=ncol,
+            fontsize=style["legend_fontsize"],
+        )
+    pdf.savefig(fig, dpi=style["dpi"], bbox_inches="tight")
+    plt.close(fig)
 
-    # Cluster-level diagnostic pages
+    pdf.close()
+
+    # Cluster-level diagnostic pages -> separate {out_name}.diagnostic.pdf
     if rdr_means is not None:
         plot_clusters(
             cluster_labels,
@@ -485,13 +515,13 @@ def plot_rdr_baf(
             expected_bafs,
             baf_taus,
             samples,
+            out_file=os.path.join(out_dir, f"{out_name}.diagnostic.pdf"),
             cluster_ids=unique_labels,
             log_rdr=log_rdr,
-            pdf=pdf,
             palette=palette,
             bin_info=bin_info,
             lim_baf=global_lim_baf,
             lim_rdr=global_lim_rdr,
+            style=style,
         )
-    pdf.close()
     return

--- a/src/hatchet/plot/plot_cn.py
+++ b/src/hatchet/plot/plot_cn.py
@@ -28,7 +28,11 @@ from hatchet.io_utils import (
     read_region_bed,
     read_seg_ucn_file,
 )
-from hatchet.plot.plot_utils import build_genome_axis, use_editable_fonts
+from hatchet.plot.plot_utils import (
+    get_plot_style,
+    build_genome_axis,
+    use_editable_fonts,
+)
 
 
 def run(args=None):
@@ -54,23 +58,25 @@ def run(args=None):
 
     ##################################################
     # parameters (styling — defaults in hatchet.yaml)
-    row_width = args["plot_row_width"]
-    row_height = args["plot_row_height"]
-    inter_sample_hspace = args["plot_inter_sample_hspace"]
-    intra_sample_hspace = args["plot_intra_sample_hspace"]
-    baf_cnp_hspace = args["plot_baf_cnp_hspace"]
+    style = get_plot_style(args)
+    row_width = style["row_width"]
+    row_height = style["row_height"]
+    inter_sample_hspace = style["inter_sample_hspace"]
+    intra_sample_hspace = style["intra_sample_hspace"]
+    baf_cnp_hspace = style["baf_cnp_hspace"]
+    markersize = style["markersize"]
 
     use_editable_fonts()
 
-    ignore_gap = not args["show_gap"]
-    dpi = args["dpi"]
-    transparent = args["transparent"]
+    ignore_gap = not style["show_gap"]
+    dpi = style["dpi"]
+    transparent = style["transparent"]
 
-    tail_alpha = args["tail_alpha"]
-    center_alpha = args["center_alpha"]
-    onetail_area = args["onetail_area"]
+    tail_alpha = style["tail_alpha"]
+    center_alpha = style["center_alpha"]
+    onetail_area = style["onetail_area"]
 
-    maxlim_fcn = args["maxlim_fcn"]
+    maxlim_fcn = style["maxlim_fcn"]
 
     # tumor clones below this per-sample prop are hidden from legends/labels
     display_min_clone_prop = args["min_prop"]
@@ -202,7 +208,7 @@ def run(args=None):
 
     ##################################################
     patient_id = args["patient_id"] or "panel"
-    ext = args["img_type"]
+    ext = style["img_type"]
     tag = solID and "." + solID
     out_1d = os.path.join(plot_dir, f"{patient_id}{tag}.1D.{ext}")
     out_1d_ab = os.path.join(plot_dir, f"{patient_id}{tag}.1D.FCN_AB.{ext}")
@@ -225,7 +231,7 @@ def run(args=None):
         intra_group_hspace=intra_sample_hspace,
         inter_group_hspace=inter_sample_hspace,
         profile_hspace=baf_cnp_hspace,
-        markersize=2.0,
+        markersize=markersize,
     )
 
     # (FCN, BAF): total FCN over minor-haplotype BAF.
@@ -278,7 +284,7 @@ def run(args=None):
             title=titles[sample],
             refline_x=0.5,
             display_min_clone_prop=display_min_clone_prop,
-            markersize=2.0,
+            markersize=markersize,
         )
         fig_2d = grid.figure
         if pdf is not None:

--- a/src/hatchet/plot/plot_cnp_panel.py
+++ b/src/hatchet/plot/plot_cnp_panel.py
@@ -16,6 +16,7 @@ from hatchet.utils import (
     setup_logging,
 )
 from hatchet.io_utils import override_solution, read_region_bed, read_seg_ucn_file
+from hatchet import filenames as fn
 from cnplot import plot_cnv_profile
 from hatchet.plot.plot_utils import build_genome_axis, use_editable_fonts
 
@@ -141,7 +142,7 @@ def run(args=None):
             bbc_path = row["PATH_TO_BBC"]
             seg_path = row["PATH_TO_SEG"]
             solfile = row.get("PATH_TO_SOLFILE", "") or None
-            gamma_file = os.path.join(os.path.dirname(bbc_path), "gammas.tsv")
+            gamma_file = os.path.join(os.path.dirname(bbc_path), fn.GAMMAS)
             bn = os.path.basename(bbc_path)
             if "tetraploid" in bn:
                 ploidy = "tetraploid"

--- a/src/hatchet/plot/plot_cnp_panel.py
+++ b/src/hatchet/plot/plot_cnp_panel.py
@@ -33,14 +33,12 @@ def run(args=None):
     plot_1d2d = args["plot_1d2d"]
     plot_summary = args["plot_summary"]
 
-    row_width = args["width"]
-    row_height = args["height"]
+    row_width = args["plot_panel_width"]
+    row_height = args["plot_panel_height"]
     show_clone_name = args["show_clone_name"]
-    show_prop = args["show_prop"]
     show_ploidy = args["show_ploidy"]
-    min_prop = args["min_prop"]
-    dpi = args["dpi"]
-    transparent = args["transparent"]
+    dpi = args["plot_dpi"]
+    transparent = args["plot_transparent"]
 
     use_editable_fonts()
 
@@ -103,21 +101,10 @@ def run(args=None):
             summary_rows.append((cancer_type, label, sid, purity, ploidy))
             logging.info(f"{label} / {sid}: purity={purity}, ploidy={ploidy}")
 
-        # Display clone names passed to cnplot via `clones=`: "Clone i" / "i", with
-        # the per-sample proportion inlined as "i (xx.xx%)" when show_prop so the
-        # label stays one line and aligns with its y-tick. cnplot reads the cn_/u_
-        # columns by that name, so rename them (and the ploidy keys) to match.
-        props0 = seg_info[[f"u_{c}" for c in clones]].iloc[0]
-        disp = {}
-        for c in clones[1:]:
-            if props0[f"u_{c}"] < min_prop:
-                continue  # hide clones below the display threshold
-            name = (
-                f"Clone {c[len('clone') :]}" if show_clone_name else c[len("clone") :]
-            )
-            if show_prop:
-                name = f"{name} ({props0[f'u_{c}'] * 100:.2f}%)"
-            disp[c] = name
+        disp = {
+            c: f"Clone {c[len('clone') :]}" if show_clone_name else c[len("clone") :]
+            for c in clones[1:]
+        }
         seg_disp = seg_info.rename(
             columns={f"cn_{c}": f"cn_{d}" for c, d in disp.items()}
             | {f"u_{c}": f"u_{d}" for c, d in disp.items()}
@@ -133,7 +120,7 @@ def run(args=None):
             ax_leg=(ax_leg if i == nrows - 1 else None),
             plot_chrname=(i == 0),
             clones=list(disp.values()),
-            show_prop=False,  # proportion is inlined into the clone name
+            show_prop=False,
             clone_ploidies=clone_ploidies,
         )
         main_axes[i].set_ylabel(label, rotation=0, ha="right", va="center")
@@ -149,6 +136,7 @@ def run(args=None):
         from hatchet.plot.plot_cn import run as run_plot_cn
 
         base_dir = os.path.dirname(os.path.abspath(out_file)) or "."
+        style_args = {k: v for k, v in args.items() if k.startswith("plot_")}
         for _, row in panel.iterrows():
             bbc_path = row["PATH_TO_BBC"]
             seg_path = row["PATH_TO_SEG"]
@@ -174,14 +162,7 @@ def run(args=None):
                     "region_bed": region_bed,
                     "plot_dir": plot_dir,
                     "ploidy": ploidy,
-                    "dpi": dpi,
-                    "img_type": "png",
-                    "transparent": transparent,
-                    "show_gap": False,
-                    "tail_alpha": 0.8,
-                    "center_alpha": 1.0,
-                    "onetail_area": 0.025,
-                    "maxlim_fcn": 30,
+                    **style_args,
                 }
             )
 

--- a/src/hatchet/plot/plot_compute_cn.py
+++ b/src/hatchet/plot/plot_compute_cn.py
@@ -18,6 +18,7 @@ from matplotlib.collections import LineCollection
 
 from cnplot import annotate_landmarks, plot_cnv_profile, plot_scatter_2d, set_palette
 from hatchet.utils import sort_df_chr
+from hatchet import filenames as fn
 from hatchet.plot import plot_cn as _plot_cn
 from hatchet.plot.plot_utils import build_genome_axis, use_editable_fonts
 
@@ -28,7 +29,7 @@ def _clones_from_cn(df):
     return ["normal"] + [f"clone{i}" for i in range(1, n)]
 
 
-def _format_pool_label(tag):
+def _fmt_pool_label(tag):
     """Convert 'pool_p0.05_s1' to 'p=0.05,s=1'."""
     m = re.match(r"pool_p([^_]+)_s(\d+)", tag)
     if m:
@@ -55,7 +56,7 @@ def plot_pool_cnp(
     dpi=150,
     solve_mode=None,
     sample_names=None,
-    out_name="pool.pdf",
+    out_name=fn.POOL_PDF,
 ):
     """Plot pool CNP panel into out_dir.
 
@@ -157,7 +158,7 @@ def plot_pool_cnp(
             show_prop=False,
         )
 
-        short_label = _format_pool_label(str(label))
+        short_label = _fmt_pool_label(str(label))
         if is_selected:
             short_label += " *"
         prop_lines = []
@@ -617,7 +618,7 @@ def run_plot_cn(args, bbc, seg, gamma_file, plot_dir, ploidy, name=None):
 
 def plot_pareto_curve(summary_df, plot_dir, reg_term, elbow_fig=None):
     """Plot REG vs IMF Pareto curves + elbow/BIC page as a multi-page PDF."""
-    outfile = os.path.join(plot_dir, "model_selection.pdf")
+    outfile = os.path.join(plot_dir, fn.MODEL_SELECTION_PDF)
     reg_col = reg_term if reg_term in summary_df.columns else "REG"
     ploidies = sorted(summary_df["ploidy"].unique())
     cmap = plt.get_cmap("tab10")

--- a/src/hatchet/plot/plot_compute_cn.py
+++ b/src/hatchet/plot/plot_compute_cn.py
@@ -18,6 +18,7 @@ from matplotlib.collections import LineCollection
 
 from cnplot import annotate_landmarks, plot_cnv_profile, plot_scatter_2d, set_palette
 from hatchet.utils import sort_df_chr
+from hatchet.plot import plot_cn as _plot_cn
 from hatchet.plot.plot_utils import build_genome_axis, use_editable_fonts
 
 
@@ -593,3 +594,101 @@ def render_cnt_tree(
 
             pdf.savefig(fig2, bbox_inches="tight", dpi=150)
             plt.close(fig2)
+
+
+def run_plot_cn(args, bbc, seg, gamma_file, plot_dir, ploidy, name=None):
+    """Auto-run plot-cn on a compute-cn solution; styling falls through to hatchet.yaml."""
+    if not os.path.exists(bbc) or not os.path.exists(seg):
+        return
+    _plot_cn.run(
+        {
+            "bbc": bbc,
+            "seg": seg,
+            "genome_size": args["genome_size"],
+            "region_bed": args["region_bed"],
+            "gamma_file": gamma_file,
+            "solfile": None,
+            "patient_id": name,
+            "plot_dir": plot_dir,
+            "ploidy": ploidy,
+        }
+    )
+
+
+def plot_pareto_curve(summary_df, plot_dir, reg_term, elbow_fig=None):
+    """Plot REG vs IMF Pareto curves + elbow/BIC page as a multi-page PDF."""
+    outfile = os.path.join(plot_dir, "model_selection.pdf")
+    reg_col = reg_term if reg_term in summary_df.columns else "REG"
+    ploidies = sorted(summary_df["ploidy"].unique())
+    cmap = plt.get_cmap("tab10")
+
+    n_pages = 0
+    with PdfPages(outfile) as pdf:
+        # One page per ploidy; overlay all n-clone solutions, each n a distinct color.
+        for ploidy in ploidies:
+            pdf_grp = summary_df[summary_df["ploidy"] == ploidy]
+            ns = sorted(pdf_grp["n_clones"].unique())
+            fig, ax = plt.subplots(figsize=(7, 5))
+
+            # Non-pareto across all n: shared light-gray backdrop
+            non_pareto = pdf_grp[~pdf_grp["is_pareto"]]
+            if len(non_pareto) > 0:
+                ax.scatter(
+                    non_pareto[reg_col],
+                    non_pareto["IMF"],
+                    c="0.8",
+                    s=15,
+                    zorder=2,
+                    alpha=0.4,
+                    linewidths=0,
+                )
+
+            for ni, n_clones in enumerate(ns):
+                grp = pdf_grp[pdf_grp["n_clones"] == n_clones]
+                color = cmap(ni % 10)
+                pareto = grp[grp["is_pareto"]].sort_values(reg_col)
+                if len(pareto) > 0:
+                    ax.plot(
+                        pareto[reg_col],
+                        pareto["IMF"],
+                        "-o",
+                        color=color,
+                        markersize=5,
+                        linewidth=1.3,
+                        zorder=4,
+                        label=f"n={n_clones}",
+                    )
+                sel = grp[grp["selected"] == "*"]
+                if len(sel) > 0:
+                    ax.scatter(
+                        sel[reg_col],
+                        sel["IMF"],
+                        facecolors=color,
+                        marker="*",
+                        s=250,
+                        zorder=5,
+                        edgecolors="black",
+                        linewidths=1,
+                    )
+
+            ax.set_xlabel(reg_col, fontsize=11)
+            ax.set_ylabel("IMF", fontsize=11)
+            ax.set_title(
+                f"{ploidy} ({len(pdf_grp)} solutions)",
+                fontsize=13,
+                fontweight="bold",
+            )
+            ax.legend(fontsize=9, title="clones")
+            ax.grid(True, alpha=0.3)
+            fig.tight_layout()
+            pdf.savefig(fig)
+            plt.close(fig)
+            n_pages += 1
+
+        # Append elbow/BIC figure as last page
+        if elbow_fig is not None:
+            pdf.savefig(elbow_fig)
+            plt.close(elbow_fig)
+            n_pages += 1
+
+    logging.info(f"wrote {outfile} ({n_pages} pages)")

--- a/src/hatchet/plot/plot_utils.py
+++ b/src/hatchet/plot/plot_utils.py
@@ -5,6 +5,18 @@ import matplotlib.pyplot as plt
 from cnplot import GenomeAxis, read_chr_sizes
 
 
+def get_plot_style(args: dict) -> dict:
+    """Bundle the ``plot_*`` styling knobs, with the ``plot_`` prefix stripped.
+
+    ``normalize_args`` already merges the hatchet.yaml ``plot_*`` defaults into
+    ``args``, so this is the single shared accessor for the plot commands: each
+    reads the keys it needs (e.g. ``style["row_width"]``, ``style["diag_hist_bins"]``).
+    Defaults therefore live only in hatchet.yaml. Non-styling ``plot_*`` keys
+    (``plot_dir``, ``plot_1d2d``, ...) come along harmlessly and are simply unread.
+    """
+    return {k[len("plot_") :]: v for k, v in args.items() if k.startswith("plot_")}
+
+
 def use_editable_fonts():
     """Embed editable fonts in vector output (keeps text selectable in pdf/ps/svg)."""
     plt.rcParams["pdf.fonttype"] = 42

--- a/src/hatchet/utils.py
+++ b/src/hatchet/utils.py
@@ -11,6 +11,8 @@ import pandas as pd
 import numpy as np
 import yaml
 
+from hatchet import filenames as fn
+
 try:
     import psutil
 except ImportError:
@@ -142,7 +144,7 @@ def add_file_logging(out_dir: str, command: str = "hatchet") -> None:
     level = (
         logging.root.level if logging.root.level != logging.WARNING else logging.INFO
     )
-    fh = logging.FileHandler(os.path.join(out_dir, f"{command}.log"), mode="w")
+    fh = logging.FileHandler(os.path.join(out_dir, fn.command_log(command)), mode="w")
     fh.setLevel(level)
     fh.setFormatter(
         logging.Formatter(

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,4 +1,4 @@
-"""Pytest fixtures for HATCHet3 integration tests."""
+"""Pytest fixtures for HATCHet integration tests."""
 
 import json
 import os

--- a/tests/simulate_bb_dir.py
+++ b/tests/simulate_bb_dir.py
@@ -1,4 +1,4 @@
-"""Simulate a synthetic bb_dir for HATCHet3 integration tests.
+"""Simulate a synthetic bb_dir for HATCHet integration tests.
 
 Generates NPZ count matrices and metadata files that match the exact format
 expected by cluster-bins (see cluster_bins.py:84-141).
@@ -227,7 +227,7 @@ def simulate_bb_dir(
 
 if __name__ == "__main__":
     parser = argparse.ArgumentParser(
-        description="Simulate synthetic bb_dir for HATCHet3"
+        description="Simulate synthetic bb_dir for HATCHet"
     )
     parser.add_argument(
         "--output_dir",

--- a/tests/test_cluster_bins.py
+++ b/tests/test_cluster_bins.py
@@ -1,4 +1,4 @@
-"""Integration tests for HATCHet3 cluster-bins step."""
+"""Integration tests for HATCHet cluster-bins step."""
 
 import os
 import pandas as pd

--- a/tests/test_compute_cn.py
+++ b/tests/test_compute_cn.py
@@ -1,4 +1,4 @@
-"""Integration tests for HATCHet3 compute-cn step."""
+"""Integration tests for HATCHet compute-cn step."""
 
 import os
 import numpy as np

--- a/tests/test_snakemake.py
+++ b/tests/test_snakemake.py
@@ -43,7 +43,7 @@ def snakemake_result(tmp_path_factory):
         "log_dir": "logs",
         "verbosity": 1,
         "threads": 1,
-        "cluster_bins": {
+        "cluster-bins": {
             "minK": 3,
             "maxK": 5,
             "t": 1e-6,
@@ -66,7 +66,7 @@ def snakemake_result(tmp_path_factory):
             "min_nbins": 10,
             "ub_nbins": 50,
         },
-        "compute_cn": {
+        "compute-cn": {
             "k": None,
             "mode": "ilp",
             "solver": "cbc",
@@ -102,16 +102,6 @@ def snakemake_result(tmp_path_factory):
             "model_select": "bic",
             "tree_file": None,
             "eps_fit": 0.01,
-        },
-        "plot_cn": {
-            "dpi": 100,
-            "img_type": "png",
-            "transparent": False,
-            "show_gap": False,
-            "tail_alpha": 0.8,
-            "center_alpha": 1.0,
-            "onetail_area": 0.025,
-            "maxlim_fcn": 30,
         },
     }
 

--- a/tests/test_snakemake.py
+++ b/tests/test_snakemake.py
@@ -1,4 +1,4 @@
-"""Integration test for the full HATCHet3 Snakemake pipeline."""
+"""Integration test for the full HATCHet Snakemake pipeline."""
 
 import os
 from pathlib import Path


### PR DESCRIPTION
Groups four related changes on `feat/plot-fixes` (squash-merges to one commit). Full test suite (63) passes; ruff check + format clean.

## Plot fixes
- Centralize all plot styling in `hatchet.yaml` (`plot_*` keys, shared `get_plot_style`); registered as hidden CLI flags.
- cluster-bins K plots split into `K{k}.pdf` (1D/2D) + `K{k}.diagnostic.pdf`; 1D unified onto plot-cn's multi-sample layout; fix axes box, titles, legend, value ranges.
- plot-panel: always show all clones (drop the multi-sample-incorrect `show_prop`/`min_prop`); forward resolved style to `plot_1d2d` sub-runs.
- Simplify pool-panel clone labels.

## Filename centralization
- New `src/hatchet/filenames.py`: single source of truth for all input/output/subdirectory names (constants + templated helpers). cluster-bins, compute-cn, evaluate, plot, and utils import from it so producer/consumer filename contracts cannot silently drift.

## Restrict pre-release solver options
- Drop the `bin_dir` U-initialization entirely (parameter + code path).
- Hide `cnt_cd` from `--mode` and its companion args (`--tree_file`, `--eps_fit`) from `--help`; still reachable internally and in tests, just not user-selectable pre-release.
- Docs synced (`reference.md`, `compute-cn.md`).

## Cleanup
- compute-cn: move `run_plot_cn`/`plot_pareto_curve` into `plot_compute_cn.py`; remove dead `filtering()`; reorder `compute_cn_utils.py` into sections.
- Remove dead `show_prop` config; fix snakemake test config section names (underscore -> hyphen); ignore `.vscode/`.
- Rename brand `HATCHet3` -> `HATCHet` (docs, metadata, test strings); the lowercase `hatchet3` env/bioconda identifier is intentionally unchanged.